### PR TITLE
Use experimental `cordyceps::List::raw_iter()` to fix miri provenance issues

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -2,6 +2,10 @@ name: Miri
 
 on: [push, pull_request]
 
+env:
+  # Currently, we use timers + sleep, which require disabling isolation
+  MIRIFLAGS: "-Zmiri-disable-isolation"
+
 jobs:
   miri:
     name: "Miri"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,8 +99,7 @@ checksum = "32b13ea120a812beba79e34316b3942a857c86ec1593cb34f27bb28272ce2cca"
 [[package]]
 name = "cordyceps"
 version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0392f465ceba1713d30708f61c160ebf4dc1cf86bb166039d16b11ad4f3b5b6"
+source = "git+https://github.com/jamesmunns/mycelium?rev=9c344032563c0b63a97f9aa16cf66aaef9eea6df#9c344032563c0b63a97f9aa16cf66aaef9eea6df"
 dependencies = [
  "loom",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,6 @@ maitake-sync = { version = "0.2.1", features = ["std"] }
 
 # [patch.crates-io]
 # sequential-storage = { path = "../sequential-storage" }
+
+[patch.crates-io]
+cordyceps = { git = "https://github.com/jamesmunns/mycelium", rev = "9c344032563c0b63a97f9aa16cf66aaef9eea6df" }


### PR DESCRIPTION
closes #9

Uses the new interface in https://github.com/hawkw/mycelium/pull/533, this DOES clear the miri issues. I also had to disable isolation, as the current test uses `sleep` which is "outside" the isolation barrier.