### PR TITLE
Rework with new trait

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,7 @@
 //! Error types used for the list
 use sequential_storage::Error as SecStorError;
 
-// use crate::intrusive::{State};
-type State = ();
+use crate::intrusive::{State};
 
 /// General error that is not specific to the flash implementation
 #[derive(Debug)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
 //! Error types used for the list
 use sequential_storage::Error as SecStorError;
 
-use crate::intrusive::{KEY_LEN, State};
+use crate::intrusive::{State};
 
 /// General error that is not specific to the flash implementation
 #[derive(Debug)]
@@ -18,7 +18,7 @@ pub enum Error {
     DuplicateKey,
     /// Node is in a state that is invalid at the particular point of operation.
     /// Contains a tuple of the node key hash and the state that was deemed invalid.
-    InvalidState([u8; KEY_LEN], State),
+    InvalidState(&'static str, State),
 }
 
 // TODO @James: I have created this error because it uses the generic <F>. Adding generics
@@ -30,11 +30,11 @@ pub enum Error {
 /// Errors during loading from and storing to flash.
 ///
 /// Sometimes specific to the flash implementation.
-pub enum LoadStoreError<F> {
+pub enum LoadStoreError {
     /// Writing to flash has failed. Contains the error returned by sequential storage.
-    FlashWrite(SecStorError<F>),
+    FlashWrite,
     /// Reading from flash has failed. Contains the error returned by sequential storage.
-    FlashRead(SecStorError<F>),
+    FlashRead,
     /// Value read back from the flash during verification did not match serialized list node.
     WriteVerificationFailed,
     /// Recoverable error to tell the caller that the list needs reading first.

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,8 @@
 //! Error types used for the list
 use sequential_storage::Error as SecStorError;
 
-use crate::intrusive::{State};
+// use crate::intrusive::{State};
+type State = ();
 
 /// General error that is not specific to the flash implementation
 #[derive(Debug)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,5 @@
 //! Error types used for the list
-use crate::intrusive::{State};
+use crate::intrusive::State;
 
 /// General error that is not specific to the flash implementation
 #[derive(Debug)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,4 @@
 //! Error types used for the list
-use sequential_storage::Error as SecStorError;
-
 use crate::intrusive::{State};
 
 /// General error that is not specific to the flash implementation

--- a/src/flash.rs
+++ b/src/flash.rs
@@ -68,3 +68,105 @@ impl<T: MultiwriteNorFlash, C: CacheImpl> Flash<T, C> {
         queue::peek(&mut self.flash, self.range.clone(), &mut self.cache, data).await
     }
 }
+
+/// A single element stored in flash
+#[derive(Debug, PartialEq)]
+pub enum Elem<'a> {
+    Start {
+        /// The "write record" sequence number
+        seq_no: u32,
+    },
+    Data {
+        /// Contains the serialized key and value for the current data element
+        data: &'a [u8],
+    },
+    End {
+        /// The "write record" sequence number. Must match `Elem::Start { seq_no }`
+        /// to properly end a "write record".
+        seq_no: u32,
+        /// The CRC32 of ALL `Elem::Data { data }` fields, in the other they appear
+        /// in the FIFO queue.
+        calc_crc: u32,
+    },
+}
+
+/// A single element yielded from a NdlElemIter implementation
+pub trait NdlElemIterNode {
+    /// Error encountered while invalidating an element
+    ///
+    /// TODO: make this a concrete type? some kind of InvalidateErrorKind bound?
+    type InvalidateError;
+
+    /// Returns the present element.
+    ///
+    /// Note: this is infallible. Errors in encoding should be detected when calling
+    /// `NdlElemIter::next()`, and elements with malformed data should not be yielded.
+    fn data(&self) -> Elem<'_>;
+
+    /// Invalidate the element.
+    ///
+    /// If this operation succeeds, the current element should NEVER be returned from
+    /// future calls to `NdlElemIter::next()`. Implementors are free to decide how this
+    /// is done. Invalidating an element MAY require time-expensive work, such as a write
+    /// or erase (for example if all nodes of a flash sector have now been invalidated),
+    /// so this should not be called in time-sensitive code.
+    ///
+    /// This method MUST be cancellation-safe, but in the case of cancellation, may
+    /// require time-expensive recovery, so cancellation of this method should be
+    /// avoided in the normal case. If this method is cancelled, the element may or
+    /// may not be invalidated, however other currently-valid data MUST NOT be lost.
+    async fn invalidate(self) -> Result<(), Self::InvalidateError>;
+}
+
+/// An iterator over `Elem`s stored in the queue.
+pub trait NdlElemIter {
+    /// Items yielded by this iterator
+    type Item: NdlElemIterNode;
+    /// The error returned when next/skip_to_seq or NdlDataStorage::iter_elems fails
+    ///
+    /// TODO: make this a concrete type? some kind of ErrorKind bound?
+    type Error;
+
+    /// Obtain the next item, in oldest-to-newest order.
+    ///
+    /// This method MUST be cancellation safe, however cancellation of this function
+    /// may require re-creation of the iterator (e.g. the iterator may return a
+    /// latched Error of some kind after cancellation). Cancellation MUST NOT lead
+    /// to data loss.
+    async fn next(&mut self) -> Result<Option<Self::Item>, Self::Error>;
+
+    /// Fast-forwards the iterator to the Elem::Start item with the given seq_no.
+    /// Returns an error if not found. If Err is returned, the iterator
+    /// is exhausted. If Ok is returned, the next call to `next` will succeed
+    /// and return an NdlElemIterNode that produces `Elem::Start { seq_no }`.
+    ///
+    /// This method MUST be cancellation safe, however cancellation of this function
+    /// may require re-creation of the iterator (e.g. the iterator may return a
+    /// latched Error of some kind after cancellation). Cancellation MUST NOT lead
+    /// to data loss.
+    async fn skip_to_seq(&mut self, seq_no: u32) -> Result<(), Self::Error>;
+}
+
+/// A storage backend representing a FIFO queue of elements
+pub trait NdlDataStorage {
+    /// The type of iterator returned by this implementation
+    type Iter: NdlElemIter;
+    /// The error returned when pushing fails
+    ///
+    /// TODO: make this a concrete type? some kind of PushErrorKind bound?
+    type PushError;
+
+    /// Returns an iterator over all elements, back to front.
+    ///
+    /// This method MUST be cancellation safe, and cancellation MUST NOT lead to
+    /// data loss.
+    async fn iter_elems(&mut self) -> Result<Self::Iter, <Self::Iter as NdlElemIter>::Error>;
+
+    /// Insert an element at the FRONT of the list.
+    ///
+    /// This method MUST be cancellation safe, however if cancelled, it is not
+    /// specified whether the item has been successfully written or not.
+    /// Cancellation MUST NOT lead to data loss, other than the element currently
+    /// being written.
+    async fn push(&mut self, data: &Elem<'_>) -> Result<(), Self::PushError>;
+}

--- a/src/flash.rs
+++ b/src/flash.rs
@@ -46,7 +46,7 @@ macro_rules! step {
                 Err(_e) => break StepResult::FlashError,
             }
         }
-    }
+    };
 }
 
 /// Fast-forwards the iterator to the Elem::Start item with the given seq_no.
@@ -112,16 +112,14 @@ impl<T: MultiwriteNorFlash + 'static, C: CacheImpl + 'static> NdlDataStorage for
                 buf[0] = ELEM_START;
                 buf[1..5].copy_from_slice(&seq_no.to_le_bytes());
                 buf
-            },
-            Elem::Data { data } => {
-                data.hdr_key_val
-            },
+            }
+            Elem::Data { data } => data.hdr_key_val,
             Elem::End { seq_no, calc_crc } => {
                 buf[0] = ELEM_END;
                 buf[1..5].copy_from_slice(&seq_no.to_le_bytes());
                 buf[5..9].copy_from_slice(&calc_crc.to_le_bytes());
                 buf.as_slice()
-            },
+            }
         };
         self.push(used).await.map_err(drop)
     }
@@ -151,7 +149,8 @@ impl<'flash, T: MultiwriteNorFlash + 'static, C: CacheImpl + 'static> NdlElemIte
         Self: 'buf,
         Self: 'iter,
     {
-        let nxt: Option<QueueIteratorEntry<'flash, 'buf, 'iter, T, C>> = self.iter.next(buf).await?;
+        let nxt: Option<QueueIteratorEntry<'flash, 'buf, 'iter, T, C>> =
+            self.iter.next(buf).await?;
         let Some(nxt) = nxt else { return Ok(None) };
         if let Some(elem) = HalfElem::from_bytes(&nxt) {
             Ok(Some(Some(FlashNode {
@@ -314,17 +313,13 @@ impl<'a> SerData<'a> {
         if let Some(f) = data.first_mut() {
             *f = ELEM_DATA;
         }
-        Self {
-            hdr_key_val: data,
-        }
+        Self { hdr_key_val: data }
     }
 
     /// Create a Serialized Data Element from an existing slice. The
     /// discriminant will NOT be written.
     pub fn from_existing(data: &'a [u8]) -> Self {
-        Self {
-            hdr_key_val: data,
-        }
+        Self { hdr_key_val: data }
     }
 
     /// Obtain the header

--- a/src/flash.rs
+++ b/src/flash.rs
@@ -2,6 +2,7 @@
 //!
 //! This module provides a `Flash` struct that wraps a MultiwriteNorFlash device
 //! and exposes async methods for queue-like operations on persistent storage.
+#![allow(async_fn_in_trait)]
 
 use core::ops::Deref;
 

--- a/src/intrusive.rs
+++ b/src/intrusive.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     error::{Error, LoadStoreError},
-    flash::{Elem, Flash, NdlDataStorage, NdlElemIter as _, NdlElemIterNode, SerData, StepResult},
+    flash::{Elem, NdlDataStorage, NdlElemIter as _, NdlElemIterNode, SerData, StepResult},
     logging::{debug, error, info},
     skip_to_seq, step,
 };
@@ -1382,7 +1382,7 @@ struct SendPtr {
 }
 unsafe impl Send for SendPtr {}
 
-pub struct KvPair<'a> {
+struct KvPair<'a> {
     key: &'a str,
     body: &'a [u8],
 }

--- a/src/intrusive.rs
+++ b/src/intrusive.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     error::{Error, LoadStoreError},
-    flash::Flash,
+    flash::{Elem, Flash, NdlDataStorage, NdlElemIter as _, NdlElemIterNode},
     logging::{debug, error, info},
 };
 use cordyceps::{
@@ -11,15 +11,10 @@ use cordyceps::{
     list::{self, IterRaw},
 };
 use core::{
-    cell::UnsafeCell,
-    fmt::Debug,
-    marker::PhantomPinned,
-    mem::MaybeUninit,
-    num::Wrapping,
-    ptr::{self, NonNull},
+    cell::UnsafeCell, fmt::Debug, marker::PhantomPinned, mem::MaybeUninit, pin::Pin, ptr::{self, NonNull}
 };
 use embedded_storage_async::nor_flash::MultiwriteNorFlash;
-use maitake_sync::{Mutex, MutexGuard, WaitQueue};
+use maitake_sync::{Mutex, WaitQueue};
 use minicbor::{
     CborLen, Decode, Encode,
     encode::write::{Cursor, EndOfSlice},
@@ -28,8 +23,222 @@ use minicbor::{
 use mutex::{ConstInit, ScopedRawMutex};
 use sequential_storage::cache::CacheImpl;
 
-/// Node counter, only an alias for `Wrapping<u8>`
-pub type Counter = Wrapping<u8>;
+enum HydrationState {
+    HydratedLatest(u32),
+    HydratedNone,
+    NotHydrated,
+}
+
+#[derive(Default)]
+struct SeqState {
+    next_seq: u32,
+    has_hydrated: bool,
+    last_three: [u32; 3],
+}
+
+impl SeqState {
+    fn insert_good(&mut self, seq: u32) {
+        assert_ne!(seq, 0);
+        // todo: smarter than this
+        let mut last_four = [
+            self.last_three[0],
+            self.last_three[1],
+            self.last_three[2],
+            seq,
+        ];
+        last_four.sort_unstable();
+        self.last_three.copy_from_slice(&last_four[1..]);
+        self.next_seq = self.last_three[2] + 1;
+    }
+}
+
+struct StorageListInner {
+    list: List<NodeHeader>,
+    seq_state: SeqState,
+}
+
+
+impl StorageListInner {
+    async fn get_or_populate_latest<S: NdlDataStorage>(&mut self, s: &mut S) -> Result<Option<u32>, LoadStoreError> {
+        if self.seq_state.has_hydrated {
+            let max = self.seq_state.last_three.iter().copied().max().unwrap_or(0);
+            if max == 0 {
+                return Ok(None);
+            } else {
+                return Ok(Some(max));
+            }
+        }
+
+        // We have NOT hydrated, do so now
+        let Ok(mut iter) = s.iter_elems().await else {
+            todo!()
+        };
+
+        let mut current: Option<u32> = None;
+        // todo: real crc
+        let mut crc = 0u32;
+
+        loop {
+            let res = iter.next().await;
+            let item = match res {
+                // Got at item
+                Ok(Some(item)) => item,
+                // end of list
+                Ok(None) => break,
+                // flash error
+                Err(_e) => todo!(),
+            };
+
+            match item.data() {
+                Elem::Start { seq_no } => {
+                    current = Some(seq_no);
+                    // todo: real crc
+                    crc = 0;
+                },
+                Elem::Data { data } => {
+                    if current.is_none() {
+                        continue;
+                    } else {
+                        // todo: real crc
+                        for b in data {
+                            crc = crc.wrapping_add((*b) as u32);
+                        }
+                    }
+                },
+                Elem::End { seq_no, calc_crc } => {
+                    let Some(seq) = current.take() else {
+                        continue;
+                    };
+                    if seq != seq_no {
+                        continue;
+                    }
+                    // todo: real crc
+                    if calc_crc != crc {
+                        continue;
+                    }
+                    self.seq_state.insert_good(seq_no);
+                },
+            }
+        }
+
+        self.seq_state.has_hydrated = true;
+        let max = self.seq_state.last_three.iter().copied().max().unwrap_or(0);
+        if max == 0 {
+            Ok(None)
+        } else {
+            Ok(Some(max))
+        }
+    }
+
+    async fn extract_all<S: NdlDataStorage>(
+        &mut self,
+        latest: u32,
+        storage: &mut S,
+        buf: &mut [u8],
+    ) -> Result<(), LoadStoreError> {
+        let Ok(mut queue_iter) = storage.iter_elems().await else {
+            todo!()
+        };
+
+        let Ok(()) = queue_iter.skip_to_seq(latest).await else {
+            todo!()
+        };
+
+        let Ok(Some(n)) = queue_iter.next().await else {
+            todo!();
+        };
+        if !matches!(n.data(), Elem::Start { seq_no } if seq_no == latest) {
+            todo!();
+        }
+
+        loop {
+            let res = queue_iter.next().await;
+            let item = match res {
+                Ok(Some(i)) => i,
+                Ok(None) => break,
+                Err(_e) => todo!(),
+            };
+            let data = match item.data() {
+                Elem::Start { .. } | Elem::End { .. } => break,
+                Elem::Data { data } => data,
+            };
+
+            let Ok(kvpair) = extract(data) else {
+                continue;
+            };
+
+            debug!(
+                "Extracted metadata: key {:?}, payload: {:?}",
+                kvpair.key, kvpair.body,
+            );
+            let Some(node_header) = find_node(&mut self.list, kvpair.key) else {
+                // No node found?
+                continue;
+            };
+
+            // SAFETY: We hold the lock, we are allowed to gain exclusive mut access
+            // to the contents of the node. We COPY OUT the vtable for later use,
+            // which is important because we might throw away our `node` ptr shortly.
+            let header_meta = {
+                let node_header = unsafe { node_header.as_ref() };
+                match node_header.state {
+                    State::Initial => Some(node_header.vtable),
+                    State::NonResident => None,
+                    State::DefaultUnwritten => None,
+                    State::ValidNoWriteNeeded => None,
+                    State::NeedsWrite => None,
+                }
+            };
+            if let Some(vtable) = header_meta {
+                // Make a node pointer from a header pointer. This *consumes* the `Pin<&mut NodeHeader>`, meaning
+                // we are free to later re-invent other mutable ptrs/refs, AS LONG AS we still treat the data
+                // as pinned.
+                let mut hdrptr: NonNull<NodeHeader> = node_header;
+                let nodeptr: NonNull<Node<()>> = hdrptr.cast();
+
+                // Note: We MUST have destroyed `node` at this point, so we don't have aliasing
+                // references of both the Node and the NodeHeader. Pointers are fine!
+                //
+                // Pass the `counter_is_some` as the `drop_old` flag because if the counter has been
+                // populated, we must have read that node from flash once already and need to drop
+                // the old value of `node.t`.
+                //
+                // TODO @James: Counter used here to indicate that the old `node.t` needs to be dropped.
+                let res = (vtable.deserialize)(nodeptr, kvpair.body);
+
+                // SAFETY: We can re-magic a reference to the header, because the NonNull<Node<()>>
+                // does not have a live reference anymore
+                let hdrmut = unsafe { hdrptr.as_mut() };
+
+                if res.is_ok() {
+                    // If it went okay, let the node know that it has been hydrated with data
+                    hdrmut.state = State::ValidNoWriteNeeded;
+                } else {
+                    // If there WAS a key, but the deser failed, this means that either the data
+                    // was corrupted, or there was a breaking schema change. Either way, we can't
+                    // particularly recover from this. We might want to log this, but exposing
+                    // the difference between this and "no data found" to the node probably won't
+                    // actually be useful.
+                    //
+                    // todo: add logs? some kind of asserts?
+                    hdrmut.state = State::NonResident;
+                }
+            }
+        }
+        todo!()
+    }
+
+    fn mark_pending_nonpop(&mut self) {
+        // Set nodes in initial states to non resident
+        for hdrmut in self.list.iter_mut() {
+            if matches!(hdrmut.state, State::Initial) {
+                unsafe {
+                    hdrmut.set_state(State::NonResident);
+                }
+            }
+        }
+    }
+}
 
 /// "Global anchor" of all storage items.
 ///
@@ -61,7 +270,7 @@ pub struct StorageList<R: ScopedRawMutex> {
     /// hold a different type T, so at a top level, we ONLY store a list of the
     /// Header, which is the first field in `Node<T>`, which is repr-C, so we
     /// can cast this back to a `Node<T>` as needed
-    list: Mutex<List<NodeHeader>, R>,
+    inner: Mutex<StorageListInner, R>,
     /// Notifies the worker task that nodes need to be read from flash.
     /// Woken when a new node is attached and requires data to be loaded.
     needs_read: WaitQueue,
@@ -169,23 +378,22 @@ pub struct NodeHeader {
     /// The doubly linked list pointers
     links: list::Links<NodeHeader>,
     /// The "key" of our "key:value" store. Must be unique across the list.
-    key: [u8; KEY_LEN],
+    key: &'static str,
     /// The current state of the node. THIS IS SAFETY LOAD BEARING whether
     /// we can access the `T` in the `Node<T>`
     state: State,
-    /// Counter that is increased on every write to flash.
-    /// This helps determine which entry is the newest, should there ever be
-    /// two entries for the same key.
-    /// A `None` value indicates that the node has not been found in flash (yet)
-    /// and the counter is not yet initialized.
-    ///
-    /// TODO: Does this need to be an option? And how can we avoid (ab)using
-    /// the `None` value as an indicator that the node hasn't been hydrated yet?
-    counter: Option<Counter>,
     /// This is the type-erased serialize/deserialize `VTable` that is
     /// unique to each `T`, and will be used by the storage worker
     /// to access the `t` indirectly for loading and storing.
     vtable: VTable,
+}
+
+impl NodeHeader {
+    unsafe fn set_state(self: Pin<&mut Self>, state: State) {
+        unsafe {
+            self.get_unchecked_mut().state = state;
+        }
+    }
 }
 
 /// State of the [`Node<T>`].
@@ -209,7 +417,7 @@ pub struct NodeHeader {
 ///                                  └──────────────│ WriteStarted │─┘
 ///                                                 └──────────────┘
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum State {
@@ -228,16 +436,6 @@ pub enum State {
     /// In this state, `t` is NOT valid, and is uninitialized. it MUST NOT be
     /// read.
     NonResident,
-    /// The node has been found but did not have the latest counter value
-    /// assigned, so it is not from the latest write. The attach() function
-    /// will set the config to the default value and return the old data, so
-    /// the user can decide.
-    ///
-    /// After assigning the default value, the state must be set to
-    /// `DefaultUnwritten`.
-    ///
-    /// TODO: Revisit this when we decided how to handle partial/interrupted writes.
-    OldData,
     /// The value has been initialized using a default value (NOT from flash)
     /// and needs to be written to flash.
     ///
@@ -268,7 +466,7 @@ type SerFn = fn(NonNull<Node<()>>, &mut [u8]) -> Result<usize, ()>;
 /// to deserialize a T from the buffer.
 ///
 /// If successful, returns the number of bytes read from the buffer.
-type DeserFn = fn(NonNull<Node<()>>, &[u8], bool) -> Result<usize, ()>;
+type DeserFn = fn(NonNull<Node<()>>, &[u8]) -> Result<usize, ()>;
 
 /// Function table for type-erased serialization and deserialization operations.
 ///
@@ -305,7 +503,17 @@ impl<R: ScopedRawMutex + ConstInit> StorageList<R> {
     /// ```
     pub const fn new() -> Self {
         Self {
-            list: Mutex::new_with_raw_mutex(List::new(), R::INIT),
+            inner: Mutex::new_with_raw_mutex(
+                StorageListInner {
+                    list: List::new(),
+                    seq_state: SeqState {
+                        next_seq: 0,
+                        has_hydrated: false,
+                        last_three: [0, 0, 0],
+                    },
+                },
+                R::INIT,
+            ),
             needs_read: WaitQueue::new(),
             needs_write: WaitQueue::new(),
             reading_done: WaitQueue::new(),
@@ -325,6 +533,7 @@ impl<R: ScopedRawMutex + ConstInit> Default for StorageList<R> {
 /// used by the "storage worker task", that decides when we actually want to
 /// interact with the flash.
 impl<R: ScopedRawMutex> StorageList<R> {
+
     /// Process any nodes that are requesting flash data
     ///
     /// ## Params:
@@ -334,190 +543,42 @@ impl<R: ScopedRawMutex> StorageList<R> {
     ///   storage can not store larger items.
     ///
     /// TODO: Document what this function does and when it must be called
-    pub async fn process_reads<T: MultiwriteNorFlash>(
+    pub async fn process_reads<S: NdlDataStorage>(
         &'static self,
-        flash: &mut Flash<T, impl CacheImpl>,
+        storage: &mut S,
         buf: &mut [u8],
-    ) -> Result<(), LoadStoreError<T::Error>> {
+    ) -> Result<(), LoadStoreError> {
         info!("Start process_reads, buffer has len {}", buf.len());
         // Lock the list, remember, if we're touching nodes, we need to have the list
         // locked the entire time!
-        let mut ls = self.list.lock().await;
+        let mut inner = self.inner.lock().await;
         debug!("process_reads locked list");
 
-        // Store the counter of the last write_confirm block we found so that later on
-        // we know if the latest counter we found has actually been confirmed
-        let mut latest_write_confirm: Option<Counter> = None;
-        let mut latest_counter: Option<Counter> = None;
+        // // Store the counter of the last write_confirm block we found so that later on
+        // // we know if the latest counter we found has actually been confirmed
+        // let mut latest_write_confirm: Option<Counter> = None;
+        // let mut latest_counter: Option<Counter> = None;
 
-        // Create a `QueueIterator` without caching
-        let mut queue_iter = flash.iter().await.map_err(LoadStoreError::FlashRead)?;
-        while let Some(item) = queue_iter
-            .next(buf)
-            .await
-            .map_err(LoadStoreError::FlashRead)?
-        {
-            // Extract metadata and payload from the item
-            let key: &[u8; KEY_LEN] = extract_key(&item).expect("Invalid item: no key");
-            latest_counter.replace(extract_counter(&item).expect("Invalid item: no counter"));
-            let payload: &[u8] = extract_payload(&item).expect("Invalid item: no payload");
+        // Have we already determined the latest valid write record?
+        let res = inner.get_or_populate_latest(storage).await?;
 
-            debug!(
-                "Extracted metadata: key {:?}, counter: {:?}, payload: {:?}",
-                key, latest_counter, payload
-            );
-            // Check for the write_confirm key and update the latest confirmed counter.
-            // TODO @James: The entire counter handling feels very unergonomic and error-prone.
-            // We should consider refactoring this logic to be more robust and easier to maintain.
-            if is_write_confirm(&item) {
-                info!("Found write_confirm for counter {:?}", latest_counter);
-                latest_write_confirm.replace(
-                    latest_counter
-                        .expect("Counter should have been replaced by value extracted from flash"),
-                ); // Safe to unwrap because we replace it before
-            } else if let Some(node_header) = find_node(&mut ls, key) {
-                // SAFETY: We hold the lock, we are allowed to gain exclusive mut access
-                // to the contents of the node. We COPY OUT the vtable for later use,
-                // which is important because we might throw away our `node` ptr shortly.
-                let header_meta = {
-                    let node_header = unsafe { node_header.as_ref() };
-                    match node_header.state {
-                        // TODO @James: Again the counter
-                        State::Initial => Some((node_header.vtable, node_header.counter.is_some())),
-                        State::NonResident => None,
-                        State::DefaultUnwritten => None,
-                        State::OldData => None,
-                        State::ValidNoWriteNeeded => None,
-                        State::NeedsWrite => None,
-                    }
-                };
-                if let Some((vtable, counter_is_some)) = header_meta {
-                    // Make a node pointer from a header pointer. This *consumes* the `Pin<&mut NodeHeader>`, meaning
-                    // we are free to later re-invent other mutable ptrs/refs, AS LONG AS we still treat the data
-                    // as pinned.
-                    let mut hdrptr: NonNull<NodeHeader> = node_header;
-                    let nodeptr: NonNull<Node<()>> = hdrptr.cast();
-
-                    // Note: We MUST have destroyed `node` at this point, so we don't have aliasing
-                    // references of both the Node and the NodeHeader. Pointers are fine!
-                    //
-                    // Pass the `counter_is_some` as the `drop_old` flag because if the counter has been
-                    // populated, we must have read that node from flash once already and need to drop
-                    // the old value of `node.t`.
-                    //
-                    // TODO @James: Counter used here to indicate that the old `node.t` needs to be dropped.
-                    let res = (vtable.deserialize)(nodeptr, payload, counter_is_some);
-
-                    // SAFETY: We can re-magic a reference to the header, because the NonNull<Node<()>>
-                    // does not have a live reference anymore
-                    let hdrmut = unsafe { hdrptr.as_mut() };
-
-                    if res.is_ok() {
-                        // If it went okay, let the node know that it has been hydrated with data
-                        // from the flash by setting its counter value
-                        //
-                        // TODO @James: This is where the counter is set as a marker. We could also alter
-                        // the node state. Not sure how to best handle this. It really also depends on what
-                        // we do with partial/interrupted writes.
-                        hdrmut
-                            .counter
-                            .replace(latest_counter.expect(
-                                "Counter should be replaced by value extracted from flash",
-                            ));
-                        self.reading_done.wake_all();
-                    } else {
-                        // If there WAS a key, but the deser failed, this means that either the data
-                        // was corrupted, or there was a breaking schema change. Either way, we can't
-                        // particularly recover from this. We might want to log this, but exposing
-                        // the difference between this and "no data found" to the node probably won't
-                        // actually be useful.
-                        //
-                        // todo: add logs? some kind of asserts?
-                        hdrmut.state = State::NonResident;
-                        self.reading_done.wake_all();
-                    }
-                }
-            }
+        // If we have something: populate all present items
+        if let Some(latest) = res {
+            inner.extract_all(latest, storage, buf).await?;
         }
 
-        // Set nodes in initial states to non resident
-        for node_header in ls.iter_raw() {
-            // Make a node pointer from a header pointer. This *consumes* the `Pin<&mut NodeHeader>`, meaning
-            // we are free to later re-invent other mutable ptrs/refs, AS LONG AS we still treat the data
-            // as pinned.
-            let mut hdrptr: NonNull<NodeHeader> = node_header;
+        // Now, we either have NOTHING, or we have populated all items that DO exist.
+        inner.mark_pending_nonpop();
 
-            // SAFETY: We can re-magic a reference to the header, because the NonNull<Node<()>>
-            // does not have a live reference anymore
-            let hdrmut = unsafe { hdrptr.as_mut() };
 
-            // TODO @James: the current handling is at least "suboptimal". Depending on the counter being
-            // Some or None and the actual value is not nice. If we can come up with a better procedure to
-            // iterate over the flash and determine which part we actually want to read/deserialize, that would
-            // make things a lot easier.
-            // I can imagine something like this (given that we ignore any incomplete writes, i.e., counter values
-            // that do not have a `write_confirm` block at the end):
-            // - Iterate over the list, searching for a write confirm block.
-            // - If none is found, treat as an empty flash and `pop` all remaining nodes off the queue (if any).
-            // - If a write_confirm block is found, store its counter value and continue searching.
-            //   -> Continue until the end of the list, updating the "latest confirmed counter"
-            //   -> Start iterating over the list again, and only when we find the first element having this
-            //      "latest confirmed counter", start deserializing the items into nodes. Continue until we hit
-            //      the write_confirm block. Mark the deserialized node as "ValidNoWriteNeeded".
-            //   -> Iterate over all elements in the list, and mark every not-hydrated (Sate::Initial) node as "NonResident".
-            //
-            // Does that make sense? Or can you think of an easier/better way of doing this?
-
-            // After reading has finished, there are several possible situations:
-            // - Node was found with the latest counter value
-            //   hdrmut.counter == latest_counter -> `ValidNoWriteNeeded`
-            // - Node was found, but with an older counter value
-            //   hdrmut.counter != latest_counter
-            //   - We have not found a write_confirm block (for the latest counter value)
-            //     latest_counter != latest_write_confirm -> `OldData` and return an error in attach
-            //   - We have found a write_confirm block (for the latest counter value)
-            //     latest_counter == latest_write_confirm -> `NonResident` and delete its payload (?)
-            // - Node was not found - regardless of a write_confirm block -> `NonResident`
-            //   hdrmut.counter == None
-            //
-            // If the hdrmut.state is not initial, the node has already been handled elsewhere
-            if let State::Initial = hdrmut.state {
-                debug!(
-                    "post-processing node in initial state with counter {:?}, latest_counter {:?} and latest_write_confirm {:?}",
-                    hdrmut.counter, latest_counter, latest_write_confirm
-                );
-                hdrmut.state = match (hdrmut.counter, latest_counter, latest_write_confirm) {
-                    // Best case: node counter matches the latest counter value
-                    (Some(counter), Some(latest), _) if counter == latest => {
-                        State::ValidNoWriteNeeded
-                    }
-                    // Node contains an old counter and the latest counter has a write_confirm block
-                    (Some(_counter), Some(latest), Some(write_confirm))
-                        if latest == write_confirm =>
-                    {
-                        State::NonResident
-                    }
-                    // Node contains an old counter but the newest one does not have a write_confirm block
-                    (Some(_counter), Some(_latest), _) => State::OldData,
-                    // Node has not occured once (hence its counter is None)
-                    (None, _, _) => State::NonResident,
-                    // Invalid: if the state is initial and the node occured, it MUST have updated
-                    // the latest_counter
-                    (Some(_), None, _) => {
-                        panic!("latest_counter has not been set. This can not happen.")
-                    }
-                };
-            }
-        }
-
-        // TODO: Clarify if we should set the counter here and whether we should already
-        // "bump" it at this point or only just before writing.
-        // @James, same story. There must be a better solution for handling the counter than this.
-        //
-        // Set the counter to the latest one because know its value here.
-        // Inside process_reads, it needs to be bumped, but there it is more difficult
-        // to find out what the latest counter was due to wrapping.
-        set_counter(&mut ls, latest_counter.unwrap_or_default());
+        // // TODO: Clarify if we should set the counter here and whether we should already
+        // // "bump" it at this point or only just before writing.
+        // // @James, same story. There must be a better solution for handling the counter than this.
+        // //
+        // // Set the counter to the latest one because know its value here.
+        // // Inside process_reads, it needs to be bumped, but there it is more difficult
+        // // to find out what the latest counter was due to wrapping.
+        // set_counter(&mut ls, latest_counter.unwrap_or_default());
 
         debug!("Reading done. Waking all.");
         self.reading_done.wake_all();
@@ -551,236 +612,237 @@ impl<R: ScopedRawMutex> StorageList<R> {
         flash: &mut Flash<F, impl CacheImpl>,
         read_buf: &mut [u8],
         serde_buf: &mut [u8],
-    ) -> Result<(), LoadStoreError<F::Error>> {
-        debug!("Start process_writes");
+    ) -> Result<(), LoadStoreError> {
+        // debug!("Start process_writes");
 
-        // Lock the list, remember, if we're touching nodes, we need to have the list
-        // locked the entire time!
-        let mut ls = self.list.lock().await;
-        debug!("process_writes locked list");
+        // // Lock the list, remember, if we're touching nodes, we need to have the list
+        // // locked the entire time!
+        // let mut inner = self.inner.lock().await;
+        // debug!("process_writes locked list");
 
-        // Set to true if any node in the list needs writing
-        let mut needs_writing = false;
+        // // Set to true if any node in the list needs writing
+        // let mut needs_writing = false;
 
-        // Track the newest counter in the list. This will be the new counter value
-        // when the list is written.
-        // If no counter is present yet, continue with the default value.
-        //
-        // TODO: Once we figure out how to handle the counter, we might want to not
-        // store the counter with every node but only once for the entire list. So
-        // we no longer have to search for the max counter value.
-        let mut max_counter: Counter = Default::default();
+        // // Track the newest counter in the list. This will be the new counter value
+        // // when the list is written.
+        // // If no counter is present yet, continue with the default value.
+        // //
+        // // TODO: Once we figure out how to handle the counter, we might want to not
+        // // store the counter with every node but only once for the entire list. So
+        // // we no longer have to search for the max counter value.
+        // let mut max_counter: Counter = Default::default();
 
-        // Iterate over all list nodes and
-        // 1. Store the counter (if present).
-        //    We technically only need the counter from one list item that has been
-        //    read from flash and has counter != None.
-        // 2. Check if any node needs writing or is in an invalid state.
-        for hdrptr in ls.iter_raw() {
-            let header = unsafe { hdrptr.as_ref() };
+        // // Iterate over all list nodes and
+        // // 1. Store the counter (if present).
+        // //    We technically only need the counter from one list item that has been
+        // //    read from flash and has counter != None.
+        // // 2. Check if any node needs writing or is in an invalid state.
+        // for hdrptr in inner.list.iter_raw() {
+        //     let header = unsafe { hdrptr.as_ref() };
 
-            // If the node has a counter, it must have been read from flash.
-            // If the counter is `None`, it can be ignored.
-            if let Some(counter) = header.counter {
-                max_counter = counter;
-            }
+        //     // If the node has a counter, it must have been read from flash.
+        //     // If the counter is `None`, it can be ignored.
+        //     if let Some(counter) = header.counter {
+        //         max_counter = counter;
+        //     }
 
-            match header.state {
-                // If no write is needed, we obviously won't write.
-                State::ValidNoWriteNeeded => (),
-                // If the node hasn't been written to flash yet and we initialized it
-                // with a Default, we now write it to flash.
-                State::DefaultUnwritten | State::NeedsWrite | State::OldData => {
-                    needs_writing = true
-                }
-                // TODO: A node may be in `Initial` state, if it has been attached but
-                // `process_reads` hasn't run, yet. Should we return early here and trigger
-                // another process_reads?
-                State::Initial => {
-                    return Err(LoadStoreError::NeedsRead);
-                }
-                // This should never appear on a list that has been processed properly.
-                // TODO @James: Not sure how we should recover from this. If it cannot happen
-                // due to invalid input, we might just as well panic.
-                State::NonResident => {
-                    debug!("process_writes() on invalid state: {:?}", header.state);
+        //     match header.state {
+        //         // If no write is needed, we obviously won't write.
+        //         State::ValidNoWriteNeeded => (),
+        //         // If the node hasn't been written to flash yet and we initialized it
+        //         // with a Default, we now write it to flash.
+        //         State::DefaultUnwritten | State::NeedsWrite | State::OldData => {
+        //             needs_writing = true
+        //         }
+        //         // TODO: A node may be in `Initial` state, if it has been attached but
+        //         // `process_reads` hasn't run, yet. Should we return early here and trigger
+        //         // another process_reads?
+        //         State::Initial => {
+        //             return Err(LoadStoreError::NeedsRead);
+        //         }
+        //         // This should never appear on a list that has been processed properly.
+        //         // TODO @James: Not sure how we should recover from this. If it cannot happen
+        //         // due to invalid input, we might just as well panic.
+        //         State::NonResident => {
+        //             debug!("process_writes() on invalid state: {:?}", header.state);
 
-                    return Err(LoadStoreError::AppError(Error::InvalidState(
-                        header.key,
-                        header.state.clone(),
-                    )));
-                }
-            }
-        }
+        //             return Err(LoadStoreError::AppError(Error::InvalidState(
+        //                 header.key,
+        //                 header.state.clone(),
+        //             )));
+        //         }
+        //     }
+        // }
 
-        // If the list is unchanged, there is no need to write it to flash!
-        if !needs_writing {
-            debug!("List does not need writing. Returning.");
-            return Ok(());
-        }
+        // // If the list is unchanged, there is no need to write it to flash!
+        // if !needs_writing {
+        //     debug!("List does not need writing. Returning.");
+        //     return Ok(());
+        // }
 
-        // TODO @James: Dion suggested we should have one retry if writing fails
-        // and then return an error. I feel like the current implementation is okay-ish,
-        // but again the counter thing feels wrong. I can't really think of something that would
-        // need to be done here at the moment, so this note is mostly for context.
+        // // TODO @James: Dion suggested we should have one retry if writing fails
+        // // and then return an error. I feel like the current implementation is okay-ish,
+        // // but again the counter thing feels wrong. I can't really think of something that would
+        // // need to be done here at the moment, so this note is mostly for context.
 
-        // Increase the counter for this list by one...
-        max_counter += Wrapping(1);
-        set_counter(&mut ls, max_counter);
+        // // Increase the counter for this list by one...
+        // max_counter += Wrapping(1);
+        // set_counter(&mut inner.list, max_counter);
 
-        debug!("Attempt write_to_flash");
-        // ... and try writing the list to flash one time.
-        // If this fails, try again. If it fails again, return the error.
-        if write_to_flash(&mut ls, serde_buf, flash).await.is_err() {
-            error!("First writing attempt failed!");
+        // debug!("Attempt write_to_flash");
+        // // ... and try writing the list to flash one time.
+        // // If this fails, try again. If it fails again, return the error.
+        // if write_to_flash(&mut inner.list, serde_buf, flash).await.is_err() {
+        //     error!("First writing attempt failed!");
 
-            // Increase the counter for this list by two
-            max_counter += Wrapping(1);
-            set_counter(&mut ls, max_counter + Wrapping(2));
-            // Try one more time, but return any error
-            write_to_flash(&mut ls, serde_buf, flash).await?;
-        }
+        //     // Increase the counter for this list by two
+        //     max_counter += Wrapping(1);
+        //     set_counter(&mut inner.list, max_counter + Wrapping(2));
+        //     // Try one more time, but return any error
+        //     write_to_flash(&mut inner.list, serde_buf, flash).await?;
+        // }
 
-        // Read back all items in the list any verify the data on the flash
-        // actually is what we wanted to write.
-        verify_list_in_flash(&mut ls, read_buf, serde_buf, flash).await?;
+        // // Read back all items in the list any verify the data on the flash
+        // // actually is what we wanted to write.
+        // verify_list_in_flash(&mut inner.list, read_buf, serde_buf, flash).await?;
 
-        // If verification succeeded, add a write_confirm block with the counter value.
-        confirm_write(flash, max_counter).await?;
+        // // If verification succeeded, add a write_confirm block with the counter value.
+        // confirm_write(flash, max_counter).await?;
 
-        // Writing the list is done. Delete all the old stuff.
-        //
-        // TODO @James: Even though there is no harm in passing the `serde_buf`
-        // (we have it either way), it is unnecessary. This function will only call
-        // seq-stor::queue::pop(), which needs a buffer to write the flash data to.
-        // But we are not interested in this data and only throw it away. Afaik,
-        // seq-stor currently does not allow to just "delete" old data and always
-        // requires `pop`. Should we attempt to optimize it or just leave it as is?
-        delete_old_items(flash, max_counter, serde_buf).await?;
+        // // Writing the list is done. Delete all the old stuff.
+        // //
+        // // TODO @James: Even though there is no harm in passing the `serde_buf`
+        // // (we have it either way), it is unnecessary. This function will only call
+        // // seq-stor::queue::pop(), which needs a buffer to write the flash data to.
+        // // But we are not interested in this data and only throw it away. Afaik,
+        // // seq-stor currently does not allow to just "delete" old data and always
+        // // requires `pop`. Should we attempt to optimize it or just leave it as is?
+        // delete_old_items(flash, max_counter, serde_buf).await?;
 
-        // The write must have succeeded. So mark all nodes accordingly.
-        for mut hdrptr in ls.iter_raw() {
-            // Mark the store as complete, wake the node if it cares about state
-            // changes.
-            //
-            // SAFETY: We hold the lock to the list, so no other thread can modify
-            // the node while we are modifying it.
-            //
-            // TODO @James: I think this is fine because we hold the lock to the list.
-            // But still, please double-check that this is really okay.
-            let hdrmut = unsafe { hdrptr.as_mut() };
-            hdrmut.state = State::ValidNoWriteNeeded;
-            self.writing_done.wake_all();
-        }
+        // // The write must have succeeded. So mark all nodes accordingly.
+        // for mut hdrptr in inner.list.iter_raw() {
+        //     // Mark the store as complete, wake the node if it cares about state
+        //     // changes.
+        //     //
+        //     // SAFETY: We hold the lock to the list, so no other thread can modify
+        //     // the node while we are modifying it.
+        //     //
+        //     // TODO @James: I think this is fine because we hold the lock to the list.
+        //     // But still, please double-check that this is really okay.
+        //     let hdrmut = unsafe { hdrptr.as_mut() };
+        //     hdrmut.state = State::ValidNoWriteNeeded;
+        //     self.writing_done.wake_all();
+        // }
 
-        Ok(())
+        // Ok(())
+        todo!()
     }
 }
 
-/// Sets the counter value for all nodes in the storage list.
-///
-/// This function iterates through all nodes in the linked list and updates their
-/// counter field to the specified value. The counter is used to track write operations
-/// and determine which entries are newest when multiple entries exist for the same key.
-///
-/// # Arguments
-/// * `ls` - A mutable guard to the locked storage list
-/// * `new_counter` - The counter value to assign to all nodes
-///
-/// # Safety
-/// This function uses unsafe code to mutate node headers through raw pointers.
-/// It is safe because the caller must hold the storage list mutex (enforced by
-/// the `MutexGuard` parameter), ensuring exclusive access to the list contents.
-///
-/// TODO: Re-evaluate whether this function is really necessary or whether we can
-/// store the counter one for the entire list when the counter handling is in better shape.
-fn set_counter(
-    ls: &mut MutexGuard<'_, List<NodeHeader>, impl ScopedRawMutex>,
-    new_counter: Counter,
-) {
-    debug!("Setting counter for list to: {}", new_counter);
-    // Update counters before writing the list to flash
-    // We do this before serialization because that may fail and
-    // we want to avoid diverging counter values...
-    for mut hdrptr in ls.iter_raw() {
-        let header = unsafe { hdrptr.as_mut() };
-        header.counter.replace(new_counter);
-    }
-}
+// /// Sets the counter value for all nodes in the storage list.
+// ///
+// /// This function iterates through all nodes in the linked list and updates their
+// /// counter field to the specified value. The counter is used to track write operations
+// /// and determine which entries are newest when multiple entries exist for the same key.
+// ///
+// /// # Arguments
+// /// * `ls` - A mutable guard to the locked storage list
+// /// * `new_counter` - The counter value to assign to all nodes
+// ///
+// /// # Safety
+// /// This function uses unsafe code to mutate node headers through raw pointers.
+// /// It is safe because the caller must hold the storage list mutex (enforced by
+// /// the `MutexGuard` parameter), ensuring exclusive access to the list contents.
+// ///
+// /// TODO: Re-evaluate whether this function is really necessary or whether we can
+// /// store the counter one for the entire list when the counter handling is in better shape.
+// fn set_counter(ls: &mut List<NodeHeader>, new_counter: Counter) {
+//     debug!("Setting counter for list to: {}", new_counter);
+//     // Update counters before writing the list to flash
+//     // We do this before serialization because that may fail and
+//     // we want to avoid diverging counter values...
+//     for mut hdrptr in ls.iter_raw() {
+//         let header = unsafe { hdrptr.as_mut() };
+//         header.counter.replace(new_counter);
+//     }
+// }
 
-/// Writes a write confirmation block to flash memory to mark a successful write operation for
-/// the specified counter.
-///
-/// This function creates and writes a special "write_confirm" block to flash that serves as
-/// a marker indicating that a write operation with the given counter value has been successful.
-/// The write_confirm block consists of an all-zeros key followed by the counter value.
-///
-/// This confirmation mechanism helps distinguish between complete and incomplete write operations
-/// during recovery, allowing the system to determine which data entries are valid and which may
-/// have been interrupted mid-write.
-///
-/// # Arguments
-/// * `flash` - A mutable reference to the Flash storage device and address range to write to
-/// * `counter` - The counter value associated with the write operation being confirmed.
-///
-/// # Returns
-/// * `Ok(())` - If the write confirmation block was successfully written to flash
-/// * `Err(LoadStoreError::FlashWrite)` - If the flash write operation failed
-async fn confirm_write<F: MultiwriteNorFlash>(
-    flash: &mut Flash<F, impl CacheImpl>,
-    counter: Counter,
-) -> Result<(), LoadStoreError<F::Error>> {
-    // Assemble a write_confirm block consisting of an all-zeros key and the counter
-    let write_confirm = &mut [0u8; KEY_LEN + 1];
-    write_confirm[KEY_LEN] = counter.0;
-    // Try writing to flash
-    flash
-        .push(write_confirm)
-        .await
-        .map_err(LoadStoreError::FlashWrite)
-}
+// /// Writes a write confirmation block to flash memory to mark a successful write operation for
+// /// the specified counter.
+// ///
+// /// This function creates and writes a special "write_confirm" block to flash that serves as
+// /// a marker indicating that a write operation with the given counter value has been successful.
+// /// The write_confirm block consists of an all-zeros key followed by the counter value.
+// ///
+// /// This confirmation mechanism helps distinguish between complete and incomplete write operations
+// /// during recovery, allowing the system to determine which data entries are valid and which may
+// /// have been interrupted mid-write.
+// ///
+// /// # Arguments
+// /// * `flash` - A mutable reference to the Flash storage device and address range to write to
+// /// * `counter` - The counter value associated with the write operation being confirmed.
+// ///
+// /// # Returns
+// /// * `Ok(())` - If the write confirmation block was successfully written to flash
+// /// * `Err(LoadStoreError::FlashWrite)` - If the flash write operation failed
+// async fn confirm_write<F: MultiwriteNorFlash>(
+//     flash: &mut Flash<F, impl CacheImpl>,
+//     counter: Counter,
+// ) -> Result<(), LoadStoreError> {
+//     // Assemble a write_confirm block consisting of an all-zeros key and the counter
+//     let write_confirm = &mut [0u8; KEY_LEN + 1];
+//     write_confirm[KEY_LEN] = counter.0;
+//     // Try writing to flash
+//     flash
+//         .push(write_confirm)
+//         .await
+//         // .map_err(LoadStoreError::FlashWrite)
+//         .map_err(|_| LoadStoreError::FlashWrite)
+// }
 
-/// Removes old flash entries until reaching the newly written list with the specified counter.
-///
-/// This function iterates through flash storage, removing outdated entries by popping them
-/// from the queue until it encounters an entry with the target counter value, which indicates
-/// the beginning of the newly written list.
-///
-/// # Arguments
-/// * `flash` - The flash storage device and address range to clean up
-/// * `counter` - The counter value that marks the start of the newly written list
-/// * `serde_buf` - Buffer used for flash operations (must be large enough for any flash item)
-///
-/// # Returns
-/// * `Ok(())` - If cleanup completed successfully
-/// * `Err(LoadStoreError::FlashRead)` - If reading from flash fails
-/// * `Err(LoadStoreError::FlashWrite)` - If removing old items fails
-async fn delete_old_items<F: MultiwriteNorFlash>(
-    flash: &mut Flash<F, impl CacheImpl>,
-    counter: Counter,
-    serde_buf: &mut [u8],
-) -> Result<(), LoadStoreError<F::Error>> {
-    // Iterate over the items in the flash.
-    // First only peek() and check if it is the desired counter.
-    // If so, return – we have reached the newly written list.
-    // If not, pop that item from the list.
-    loop {
-        if let Some(item) = flash
-            .peek(serde_buf)
-            .await
-            .map_err(LoadStoreError::FlashRead)?
-        {
-            if extract_counter(item).is_ok_and(|c| c == counter) {
-                return Ok(());
-            } else {
-                flash
-                    .pop(serde_buf)
-                    .await
-                    .map_err(LoadStoreError::FlashWrite)?;
-            }
-        }
-    }
-}
+// /// Removes old flash entries until reaching the newly written list with the specified counter.
+// ///
+// /// This function iterates through flash storage, removing outdated entries by popping them
+// /// from the queue until it encounters an entry with the target counter value, which indicates
+// /// the beginning of the newly written list.
+// ///
+// /// # Arguments
+// /// * `flash` - The flash storage device and address range to clean up
+// /// * `counter` - The counter value that marks the start of the newly written list
+// /// * `serde_buf` - Buffer used for flash operations (must be large enough for any flash item)
+// ///
+// /// # Returns
+// /// * `Ok(())` - If cleanup completed successfully
+// /// * `Err(LoadStoreError::FlashRead)` - If reading from flash fails
+// /// * `Err(LoadStoreError::FlashWrite)` - If removing old items fails
+// async fn delete_old_items<F: MultiwriteNorFlash>(
+//     flash: &mut Flash<F, impl CacheImpl>,
+//     counter: Counter,
+//     serde_buf: &mut [u8],
+// ) -> Result<(), LoadStoreError> {
+//     // Iterate over the items in the flash.
+//     // First only peek() and check if it is the desired counter.
+//     // If so, return – we have reached the newly written list.
+//     // If not, pop that item from the list.
+//     loop {
+//         if let Some(item) = flash
+//             .peek(serde_buf)
+//             .await
+//             // .map_err(LoadStoreError::FlashRead)?
+//             .map_err(|_| LoadStoreError::FlashRead)?
+//         {
+//             if extract_counter(item).is_ok_and(|c| c == counter) {
+//                 return Ok(());
+//             } else {
+//                 flash
+//                     .pop(serde_buf)
+//                     .await
+//                     // .map_err(LoadStoreError::FlashWrite)?;
+//                     .map_err(|_| LoadStoreError::FlashWrite)?;
+//             }
+//         }
+//     }
+// }
 /// Verifies that the storage list was correctly written to flash memory.
 ///
 /// This function compares each node in the storage list against the corresponding
@@ -804,63 +866,64 @@ async fn delete_old_items<F: MultiwriteNorFlash>(
 /// The caller must hold the storage list mutex (enforced by the `MutexGuard` parameter)
 /// to ensure exclusive access during verification.
 async fn verify_list_in_flash<F: MultiwriteNorFlash>(
-    ls: &mut MutexGuard<'_, List<NodeHeader>, impl ScopedRawMutex>,
+    ls: &mut List<NodeHeader>,
     read_buf: &mut [u8],
     serde_buf: &mut [u8],
     flash: &mut Flash<F, impl CacheImpl>,
-) -> Result<(), LoadStoreError<F::Error>> {
-    // Create a `QueueIterator`
-    let mut queue_iter = flash.iter().await.map_err(LoadStoreError::FlashRead)?;
+) -> Result<(), LoadStoreError> {
+    // // Create a `QueueIterator`
+    // let mut queue_iter = flash.iter().await.map_err(|_| LoadStoreError::FlashRead)?;
 
-    // Make it Send
-    let iter = StaticRawIter {
-        iter: ls.iter_raw(),
-    };
+    // // Make it Send
+    // let iter = StaticRawIter {
+    //     iter: ls.iter_raw(),
+    // };
 
-    // Set true on the first occurence of the correct counter.
-    // That means, we have hit the first element of the newly-written list.
-    let mut counter_found = false;
+    // // Set true on the first occurence of the correct counter.
+    // // That means, we have hit the first element of the newly-written list.
+    // let mut counter_found = false;
 
-    // Iterate over the nodes in the list
-    for hdrptr in iter {
-        let header = unsafe { hdrptr.ptr.as_ref() };
+    // // Iterate over the nodes in the list
+    // for hdrptr in iter {
+    //     let header = unsafe { hdrptr.ptr.as_ref() };
 
-        // TODO @James: Can you think of an easier way of doing things here?
-        // Especially the `!counter.is_ok_and()...` part bothers me.
+    //     // TODO @James: Can you think of an easier way of doing things here?
+    //     // Especially the `!counter.is_ok_and()...` part bothers me.
 
-        // Get the next item from the queue.
-        // This loop will continue until we hit the first correct counter
-        // in the flash. That must be the beginning of the newly-written list.
-        // Then serialize the node and compare to the item in flash.
-        while let Some(item) = queue_iter
-            .next(read_buf)
-            .await
-            .map_err(LoadStoreError::FlashRead)?
-        {
-            // Skip items until we find one with the expected counter value.
-            // This identifies the start of the newly-written list in flash.
-            // Once found, we verify each subsequent item matches our serialized nodes.
-            if !counter_found
-                && !extract_counter(&item).is_ok_and(|counter| {
-                    counter == header.counter.expect("Counter should have been set!")
-                })
-            {
-                continue;
-            }
-            counter_found = true;
+    //     // Get the next item from the queue.
+    //     // This loop will continue until we hit the first correct counter
+    //     // in the flash. That must be the beginning of the newly-written list.
+    //     // Then serialize the node and compare to the item in flash.
+    //     while let Some(item) = queue_iter
+    //         .next(read_buf)
+    //         .await
+    //         .map_err(|_| LoadStoreError::FlashRead)?
+    //     {
+    //         // Skip items until we find one with the expected counter value.
+    //         // This identifies the start of the newly-written list in flash.
+    //         // Once found, we verify each subsequent item matches our serialized nodes.
+    //         if !counter_found
+    //             && !extract_counter(&item).is_ok_and(|counter| {
+    //                 counter == header.counter.expect("Counter should have been set!")
+    //             })
+    //         {
+    //             continue;
+    //         }
+    //         counter_found = true;
 
-            // Serialize into the second buffer so we know what it *should* look like.
-            let res = serialize_node(hdrptr.ptr, serde_buf);
+    //         // Serialize into the second buffer so we know what it *should* look like.
+    //         let res = serialize_node(hdrptr.ptr, serde_buf);
 
-            // Check if value in flash matches the serialized node
-            if !res.is_ok_and(|len| item.into_buf() == &serde_buf[..len]) {
-                return Err(LoadStoreError::WriteVerificationFailed);
-            }
-            // Value matched, so we can continue with the next list node
-            break;
-        }
-    }
-    Ok(())
+    //         // Check if value in flash matches the serialized node
+    //         if !res.is_ok_and(|len| item.into_buf() == &serde_buf[..len]) {
+    //             return Err(LoadStoreError::WriteVerificationFailed);
+    //         }
+    //         // Value matched, so we can continue with the next list node
+    //         break;
+    //     }
+    // }
+    // Ok(())
+    todo!()
 }
 /// Writes all nodes in the storage list to flash memory.
 ///
@@ -884,10 +947,10 @@ async fn verify_list_in_flash<F: MultiwriteNorFlash>(
 ///   to ensure exclusive access during the write operation.
 /// - The list nodes must be in a valid state for writing (e.g., counter must be set)
 async fn write_to_flash<F: MultiwriteNorFlash>(
-    ls: &mut MutexGuard<'_, List<NodeHeader>, impl ScopedRawMutex>,
+    ls: &mut List<NodeHeader>,
     buf: &mut [u8],
     flash: &mut Flash<F, impl CacheImpl>,
-) -> Result<(), LoadStoreError<F::Error>> {
+) -> Result<(), LoadStoreError> {
     let iter = StaticRawIter {
         iter: ls.iter_raw(),
     };
@@ -906,7 +969,7 @@ async fn write_to_flash<F: MultiwriteNorFlash>(
             flash
                 .push(&buf[..used])
                 .await
-                .map_err(LoadStoreError::FlashWrite)?;
+                .map_err(|_| LoadStoreError::FlashWrite)?;
         } else {
             // TODO @James: This comment is still from your first version. I am
             // unsure how up to date this is and whether or not this becomes a
@@ -949,10 +1012,9 @@ where
             inner: UnsafeCell::new(Node {
                 header: NodeHeader {
                     links: list::Links::new(),
-                    key: const_fnv1a_hash::fnv1a_hash_str_32(path).to_le_bytes(),
+                    key: path,
                     state: State::Initial,
                     vtable: VTable::for_ty::<T>(),
-                    counter: None,
                 },
                 t: MaybeUninit::uninit(),
                 _pin: PhantomPinned,
@@ -985,7 +1047,7 @@ where
 
         // Add a scope so that the Lock on the List is dropped
         {
-            let mut ls = list.list.lock().await;
+            let mut inner = list.inner.lock().await;
             debug!("attach() got Lock on list");
 
             let nodeptr: *mut Node<T> = self.inner.get();
@@ -999,11 +1061,11 @@ where
             // SAFETY: We hold the lock, we are allowed to gain exclusive mut access
             // to the contents of the node.
             let key = unsafe { &nodenn.as_ref().header.key };
-            if find_node(&mut ls, key).is_some() {
+            if find_node(&mut inner.list, key).is_some() {
                 error!("Key already in use: {:?}", key);
                 panic!("Node with the same key-hash already in the list");
             } else {
-                ls.push_front(hdrnn);
+                inner.list.push_front(hdrnn);
             }
             // Let read task know we have work
             list.needs_read.wake();
@@ -1019,7 +1081,7 @@ where
                 .expect("waitcell should never close");
 
             // We need the lock to look at ourself!
-            let _lock = list.list.lock().await;
+            let inner = list.inner.lock().await;
 
             // We have the lock, we can gaze into the UnsafeCell
             let nodeptr: *mut Node<T> = self.inner.get();
@@ -1043,26 +1105,6 @@ where
                     break;
                 }
                 State::DefaultUnwritten => todo!("shouldn't observe this in attach"),
-                State::OldData => {
-                    // TODO @James: Please verify whether this is safe. It's basically
-                    // a copy from what the `write()` function does.
-                    // Maybe this will soon be gone, however, if we decide that we ignore
-                    // any "new data" that was part of a partial/interrupted write.
-                    //
-                    // SAFETY: we may access `noderef.t` because we hold the lock.
-                    // We do a swap instead of a write here, to ensure that we
-                    // call `drop` on the "old" contents of the buffer.
-                    let mut t = T::default();
-                    unsafe {
-                        let mutref: &mut T = noderef.t.assume_init_mut();
-                        core::mem::swap(&mut t, mutref);
-                    }
-
-                    // Since we set the default value, it is effectively this state
-                    noderef.header.state = State::DefaultUnwritten;
-
-                    return Err((StorageListNodeHandle { list, inner: self }, t));
-                }
                 State::ValidNoWriteNeeded => break,
                 State::NeedsWrite => todo!("shouldn't observe this in attach"),
             }
@@ -1091,7 +1133,7 @@ where
     /// So just hold the lock and copy out.
     pub async fn load(&self) -> Result<T, Error> {
         // Lock the list if we look at ourself
-        let _lock = self.list.list.lock().await;
+        let _inner = self.list.inner.lock().await;
 
         let nodeptr: *mut Node<T> = self.inner.inner.get();
         let noderef = unsafe { &mut *nodeptr };
@@ -1102,10 +1144,10 @@ where
             // of code while holding a lock ourselves
             //
             // TODO @James: Again, if we are in an invalid state, should we rather panic?
-            State::Initial | State::NonResident | State::OldData => {
+            State::Initial | State::NonResident => {
                 return Err(Error::InvalidState(
                     noderef.header.key,
-                    noderef.header.state.clone(),
+                    noderef.header.state,
                 ));
             }
             // Handle all states here explicitly to avoid bugs with a catch-all
@@ -1117,18 +1159,18 @@ where
 
     /// Write data to the buffer, and mark the buffer as "needs to be flushed".
     pub async fn write(&self, t: &T) -> Result<(), Error> {
-        let _lock = self.list.list.lock().await;
+        let _inner = self.list.inner.lock().await;
 
         let nodeptr: *mut Node<T> = self.inner.inner.get();
         let noderef = unsafe { &mut *nodeptr };
         match noderef.header.state {
             // `Initial` and `NonResident` can not occur for the same reason as
             // outlined in load(). OldData should have been replaced with a Default value.
-            State::Initial | State::NonResident | State::OldData => {
+            State::Initial | State::NonResident => {
                 debug!("write() on invalid state: {:?}", noderef.header.state);
                 return Err(Error::InvalidState(
                     noderef.header.key,
-                    noderef.header.state.clone(),
+                    noderef.header.state,
                 ));
             }
             State::DefaultUnwritten | State::ValidNoWriteNeeded | State::NeedsWrite => {}
@@ -1285,7 +1327,7 @@ where
 /// - The buffer contains valid CBOR data that can be decoded into type `T`
 ///
 /// TODO @James: Please review these safety requirements. Are they correct and complete?
-fn deserialize<T>(node: NonNull<Node<()>>, buf: &[u8], drop_old: bool) -> Result<usize, ()>
+fn deserialize<T>(node: NonNull<Node<()>>, buf: &[u8]) -> Result<usize, ()>
 where
     T: 'static,
     T: CborLen<()>,
@@ -1296,7 +1338,7 @@ where
 
     let res = minicbor::decode::<T>(buf);
 
-    let mut t = match res {
+    let t = match res {
         Ok(t) => t,
         // TODO: Should we return the actual error here or not?
         Err(_) => return Err(()),
@@ -1304,18 +1346,10 @@ where
 
     let len = len_with(&t, &mut ());
 
-    // If we are asked to drop the old value, we need to swap `t`
-    // with the Node's `t`. Otherwise, just store the `t`.
-    if drop_old {
-        // We do a swap instead of a write here, to ensure that we
-        // call `drop` on the "old" contents of the buffer.
-        unsafe {
-            let mutref: &mut T = noderef.t.assume_init_mut();
-            core::mem::swap(&mut t, mutref);
-        }
-    } else {
-        noderef.t = MaybeUninit::new(t);
-    }
+    // TODO(AJM): anything to do here?
+    assert!(matches!(noderef.header.state, State::Initial));
+    noderef.t = MaybeUninit::new(t);
+
     Ok(len)
 }
 
@@ -1365,11 +1399,10 @@ struct SendPtr {
 }
 unsafe impl Send for SendPtr {}
 
-/// Node Key length in bytes
-///
-/// TODO @James: Should this rather be a parameter and be tied to a hash function?
-/// It's pretty redundant because if we use a 32-bit hash, this will always be 4.
-pub const KEY_LEN: usize = 4;
+pub struct KvPair<'a> {
+    key: &'a str,
+    body: &'a [u8],
+}
 
 /// Find a `NodeHeader` with the given `key` in the storage list.
 ///
@@ -1388,9 +1421,9 @@ pub const KEY_LEN: usize = 4;
 /// # Safety
 /// This function is safe to call as long as the caller holds the storage list mutex
 /// (which is enforced by taking a `MutexGuard` parameter).
-fn find_node<R: ScopedRawMutex>(
-    list: &mut MutexGuard<List<NodeHeader>, R>,
-    key: &[u8; KEY_LEN],
+fn find_node(
+    list: &mut List<NodeHeader>,
+    key: &str,
 ) -> Option<NonNull<NodeHeader>> {
     // TODO @James: Same as before, please check if the safety requirements in the docstring
     // are enough (together with explicity requiring a MutexGuard)
@@ -1400,38 +1433,31 @@ fn find_node<R: ScopedRawMutex>(
     // SAFETY: Since we hold a lock on the List (taking MutexGuard as a parameter)
     // we have exclusive access to the contents of the list.
     list.iter_raw()
-        .find(|item| unsafe { item.as_ref() }.key == *key)
+        .find(|item| unsafe { item.as_ref() }.key == key)
 }
 
 /// Get the `key` bytes from a list item in the flash.
 ///
 /// Used to extract the key from a `QueueIteratorItem`.
-fn extract_key(item: &[u8]) -> Result<&[u8; KEY_LEN], Error> {
-    item[..KEY_LEN]
-        .try_into()
-        .map_err(|_| Error::Deserialization)
+fn extract(item: &[u8]) -> Result<KvPair<'_>, Error> {
+    let Ok(key) = minicbor::decode::<&str>(item) else {
+        return Err(Error::Deserialization);
+    };
+    let len = len_with(key, &mut ());
+    let Some(remain) = item.get(len..) else {
+        return Err(Error::Deserialization);
+    };
+    Ok(KvPair { key, body: remain })
 }
 
-/// Get the `counter` byte from a list item in the flash.
-///
-/// Used to extract the counter from a `QueueIteratorItem`.
-fn extract_counter(item: &[u8]) -> Result<Counter, Error> {
-    item.get(KEY_LEN)
-        .ok_or(Error::Deserialization)
-        .map(|c| Wrapping(*c))
-}
-
-/// Get the `payload` bytes from a list item in the flash.
-///
-/// Used to extract the payload from a `QueueIteratorItem`.
-fn extract_payload(item: &[u8]) -> Result<&[u8], Error> {
-    item.get(KEY_LEN + 1..).ok_or(Error::Deserialization)
-}
-
-/// Check if the list item in the flash is a `write_confirm` block.
-fn is_write_confirm(item: &[u8]) -> bool {
-    item[..KEY_LEN].iter().all(|&elem| elem == 0)
-}
+// /// Get the `counter` byte from a list item in the flash.
+// ///
+// /// Used to extract the counter from a `QueueIteratorItem`.
+// fn extract_counter(item: &[u8]) -> Result<Counter, Error> {
+//     item.get(KEY_LEN)
+//         .ok_or(Error::Deserialization)
+//         .map(|c| Wrapping(*c))
+// }
 
 /// Serialize a storage node by writing its key, counter, and payload data
 /// into the provided buffer.
@@ -1455,330 +1481,352 @@ fn is_write_confirm(item: &[u8]) -> bool {
 /// - The storage list mutex is held during the entire operation
 /// - The buffer is large enough to hold the serialized data
 pub fn serialize_node(
-    headerptr: NonNull<NodeHeader>,
-    serde_buf: &mut [u8],
+    _headerptr: NonNull<NodeHeader>,
+    _serde_buf: &mut [u8],
 ) -> Result<usize, Error> {
-    let (vtable, key, counter) = {
-        let node = unsafe { headerptr.as_ref() };
-        (node.vtable, node.key, node.counter)
-    };
+    todo!()
+    // let (vtable, key, counter) = {
+    //     let node = unsafe { headerptr.as_ref() };
+    //     (node.vtable, node.key, node.counter)
+    // };
 
-    debug!(
-        "serializing node with key <{:?}>, counter <{:?}>",
-        key, counter
-    );
-    debug_assert!(
-        counter.is_some(),
-        "Counter value expected to be set before writing the list"
-    );
+    // debug!(
+    //     "serializing node with key <{:?}>, counter <{:?}>",
+    //     key, counter
+    // );
+    // debug_assert!(
+    //     counter.is_some(),
+    //     "Counter value expected to be set before writing the list"
+    // );
 
-    let nodeptr: NonNull<Node<()>> = headerptr.cast();
+    // let nodeptr: NonNull<Node<()>> = headerptr.cast();
 
-    // Serialize metadata + payload into buffer
-    serde_buf[0..KEY_LEN].copy_from_slice(&key);
-    serde_buf[KEY_LEN] = counter.map(|c| c.0).unwrap_or(0);
-    (vtable.serialize)(nodeptr, &mut serde_buf[KEY_LEN + 1..])
-        .map(|len| len + KEY_LEN + 1)
-        .map_err(|_| Error::Serialization)
+    // // Serialize metadata + payload into buffer
+    // serde_buf[0..KEY_LEN].copy_from_slice(&key);
+    // serde_buf[KEY_LEN] = counter.map(|c| c.0).unwrap_or(0);
+    // (vtable.serialize)(nodeptr, &mut serde_buf[KEY_LEN + 1..])
+    //     .map(|len| len + KEY_LEN + 1)
+    //     .map_err(|_| Error::Serialization)
 }
 
-// TODO @James: I've already created some of the test cases from
-// https://github.com/tweedegolf/cfg-noodle/issues/16 in tests/integration_tests.rs
-// and the tests in this module are mostly obsolete. What is still missing, though, are
-// unit tests that could be (re)used for fuzzing.
-// I think we should first decide on entire counter handling before writing these since
-// the function signatures and output might change. But once that is done, we can gather
-// a list of tests that should be implemented and we both write some of them.
-// And we might want to keep in mind that the fuzzer probably wants to reuse some of that code.
-// In general, we probably must decide on what the interface to the outside looks, first.
 #[cfg(test)]
 mod test {
-    extern crate std;
-    use super::*;
+    use super::SeqState;
 
-    use core::time::Duration;
-    use minicbor::CborLen;
-    use mutex::raw_impls::cs::CriticalSectionRawMutex;
-    use sequential_storage::cache::NoCache;
-    use sequential_storage::mock_flash::MockFlashBase;
-    use sequential_storage::mock_flash::WriteCountCheck;
-    use test_log::test;
-    use tokio::task::JoinHandle;
-    use tokio::time::sleep;
-
-    #[derive(Debug, Encode, Decode, Clone, PartialEq, CborLen)]
-    struct PositronConfig {
-        #[n(0)]
-        up: u8,
-        #[n(1)]
-        down: u16,
-        #[n(2)]
-        strange: u32,
-    }
-
-    impl Default for PositronConfig {
-        fn default() -> Self {
-            Self {
-                up: 10,
-                down: 20,
-                strange: 103,
-            }
-        }
-    }
-
-    // TODO: This type, the get_mock_flash() and worker_task() are not only specific to sequential storage's
-    // mock flash, but also copy&pasted in the integration tests. If we go with the flash-trait approach,
-    // these could be generic.
-    type MockFlash = Flash<MockFlashBase<10, 16, 256>, NoCache>;
-
-    fn get_mock_flash() -> MockFlash {
-        let mut flash = MockFlashBase::<10, 16, 256>::new(WriteCountCheck::OnceOnly, None, true);
-        // TODO: Figure out why miri tests with unaligned buffers and whether
-        // this needs any fixing. For now just disable the alignment check in MockFlash
-        flash.alignment_check = false;
-        Flash::new(flash, 0x0000..0x1000, NoCache::new())
-    }
-
-    fn worker_task<R: ScopedRawMutex + Sync>(
-        list: &'static StorageList<R>,
-        mut flash: MockFlash,
-        mut read_buf: [u8; 4096],
-        mut serde_buf: [u8; 4096],
-    ) -> JoinHandle<()> {
-        tokio::task::spawn(async move {
-            loop {
-                info!("worker_task waiting for needs_* signal");
-                match embassy_futures::select::select(
-                    list.needs_read.wait(),
-                    list.needs_write.wait(),
-                )
-                .await
-                {
-                    embassy_futures::select::Either::First(_) => {
-                        info!("worker task got needs_read signal");
-                        if let Err(e) = list.process_reads(&mut flash, &mut read_buf).await {
-                            error!("Error in process_reads: {:?}", e);
-                        }
-                    }
-                    embassy_futures::select::Either::Second(_) => {
-                        info!("worker task got needs_write signal");
-                        if let Err(e) = list
-                            .process_writes(&mut flash, &mut read_buf, &mut serde_buf)
-                            .await
-                        {
-                            error!("Error in process_writes: {:?}", e);
-                        }
-
-                        info!("Wrote to flash: {}", flash.flash().print_items().await);
-                    }
-                }
-            }
-        })
-    }
-
-    #[test(tokio::test)]
-    async fn test_two_configs() {
-        static GLOBAL_LIST: StorageList<CriticalSectionRawMutex> = StorageList::new();
-        static POSITRON_CONFIG1: StorageListNode<PositronConfig> =
-            StorageListNode::new("positron/config1");
-        static POSITRON_CONFIG2: StorageListNode<PositronConfig> =
-            StorageListNode::new("positron/config2");
-
-        let flash = get_mock_flash();
-
-        let read_buf = [0u8; 4096];
-        let serde_buf = [0u8; 4096];
-
-        info!("Spawn worker_task");
-        let worker_task = worker_task(&GLOBAL_LIST, flash, read_buf, serde_buf);
-
-        // Obtain a handle for the first config
-        let config_handle = match POSITRON_CONFIG1.attach(&GLOBAL_LIST).await {
-            Ok(ch) => ch,
-            Err(_) => panic!("Could not attach config 1 to list"),
-        };
-
-        // Obtain a handle for the second config. This should _not_ error!
-        if POSITRON_CONFIG2.attach(&GLOBAL_LIST).await.is_err() {
-            panic!("Could not attach config 2 to list");
-        }
-
-        // Load data for the first handle
-        let data: PositronConfig = config_handle
-            .load()
-            .await
-            .expect("Loading config should not fail");
-        info!("T3 Got {data:?}");
-
-        // Assert that the counter is at default value because we
-        // haven't read this from flash
-        assert_eq!(
-            unsafe { config_handle.inner.inner.get().as_ref() }
-                .expect("Getting inner at this point should not fail")
-                .header
-                .counter,
-            Some(Counter::default())
-        );
-
-        // Write a new config to first handle
-        let new_config = PositronConfig {
-            up: 15,
-            down: 25,
-            strange: 108,
-        };
-        config_handle
-            .write(&new_config)
-            .await
-            .expect("Writing config to node should not fail");
-
-        // Give the worker_task some time to process the write
-        sleep(Duration::from_millis(100)).await;
-
-        // Assert that the loaded value equals the written value
-        assert_eq!(
-            config_handle
-                .load()
-                .await
-                .expect("Loading config should not fail"),
-            new_config
-        );
-
-        // Assert that the counter is now 1
-        assert_eq!(
-            unsafe { config_handle.inner.inner.get().as_ref() }
-                .expect("Getting inner at this point should not fail")
-                .header
-                .counter
-                .expect("Counter should have a value at this point"),
-            Wrapping(1)
-        );
-
-        // Wait for the worker task to finish
-        let _ = tokio::time::timeout(Duration::from_secs(2), worker_task).await;
-    }
-
-    #[test(tokio::test)]
-    async fn test_load_existing() {
-        // This test will write a config to the flash first and then read it back to check
-        // whether reading an item from flash works.
-
-        static GLOBAL_LIST: StorageList<CriticalSectionRawMutex> = StorageList::new();
-        static POSITRON_CONFIG: StorageListNode<PositronConfig> =
-            StorageListNode::new("positron/config");
-
-        let mut serde_buf = [0u8; 4096];
-        let read_buf = [0u8; 4096];
-
-        // Serialize the custom_config config so we can write it to our flash
-        let custom_config = PositronConfig {
-            up: 1,
-            down: 22,
-            strange: 333,
-        };
-
-        // TODO: The following pointer operations are a very cumbersome way
-        // of serializing the node just so we can push it to the flash and read back...
-        unsafe {
-            POSITRON_CONFIG
-                .inner
-                .get()
-                .as_mut()
-                .expect("Pointer should not be null")
-                .t = MaybeUninit::new(custom_config.clone());
-            POSITRON_CONFIG
-                .inner
-                .get()
-                .as_mut()
-                .expect("Pointer should not be null")
-                .header
-                .counter = Some(Wrapping(0));
-        }
-        let nodeptr: *mut Node<PositronConfig> = POSITRON_CONFIG.inner.get();
-        let nodenn: NonNull<Node<PositronConfig>> = unsafe { NonNull::new_unchecked(nodeptr) };
-        let hdrnn: NonNull<NodeHeader> = nodenn.cast();
-
-        let used = serialize_node(hdrnn, &mut serde_buf).expect("Serializing node should not fail");
-
-        // Now serialize again by calling encode() directly and verify both match
-        let mut serialize_control = std::vec![];
-        let len = len_with(&custom_config, &mut ());
-        minicbor::encode(&custom_config, &mut serialize_control).expect("Encoding should not fail");
-        // The serialized node will contain some metadata, but the last `len` bytes must match
-        assert_eq!(serialize_control[..len], serde_buf[used - len..used]);
-
-        let mut flash = get_mock_flash();
-        info!("Pushing to flash: {:?}", &serde_buf[..used]);
-        flash
-            .push(&serde_buf[..used])
-            .await
-            .expect("pushing to flash should not fail here");
-
-        let worker_task = worker_task(&GLOBAL_LIST, flash, read_buf, serde_buf);
-
-        // Obtain a handle for the config. It should match the custom_config.
-        // This should _not_ error!
-        let expecting_already_present = match POSITRON_CONFIG.attach(&GLOBAL_LIST).await {
-            Ok(ch) => ch,
-            Err(_) => panic!("Could not attach config to list"),
-        };
-
-        assert_eq!(
-            custom_config,
-            expecting_already_present
-                .load()
-                .await
-                .expect("Loading config should not fail"),
-            "Key should already be present"
-        );
-
-        expecting_already_present
-            .write(&custom_config)
-            .await
-            .expect("Writing config to node should not fail");
-
-        sleep(Duration::from_millis(50)).await;
-
-        // Assert that the counter is now 1
-        assert_eq!(
-            unsafe { expecting_already_present.inner.inner.get().as_ref() }
-                .expect("Node should exist")
-                .header
-                .counter
-                .expect("Counter should have a value"),
-            Wrapping(1)
-        );
-
-        // Wait for the worker task to finish
-        let _ = tokio::time::timeout(Duration::from_secs(2), worker_task).await;
-    }
-
-    #[test(tokio::test)]
-    #[should_panic]
-    async fn test_duplicate_key() {
-        static GLOBAL_LIST: StorageList<CriticalSectionRawMutex> = StorageList::new();
-        static POSITRON_CONFIG1: StorageListNode<PositronConfig> =
-            StorageListNode::new("positron/config");
-        static POSITRON_CONFIG2: StorageListNode<PositronConfig> =
-            StorageListNode::new("positron/config");
-
-        let flash = get_mock_flash();
-
-        info!("Spawn worker_task");
-        let serde_buf = [0u8; 4096];
-        let read_buf = [0u8; 4096];
-        let worker_task = worker_task(&GLOBAL_LIST, flash, read_buf, serde_buf);
-
-        // Obtain a handle for the first config
-        let _config_handle = match POSITRON_CONFIG1.attach(&GLOBAL_LIST).await {
-            Ok(ch) => ch,
-            Err(_) => panic!("Could not attach config 1 to list"),
-        };
-
-        // Obtain a handle for the second config. It has the same key as the first.
-        // This must panic!
-        let _expecting_panic = POSITRON_CONFIG2.attach(&GLOBAL_LIST).await;
-
-        // Wait for the worker task to finish
-        let _ = tokio::time::timeout(Duration::from_secs(2), worker_task).await;
+    #[test]
+    fn seq_sort() {
+        let mut s = SeqState::default();
+        assert_eq!(s.last_three, [0, 0, 0]);
+        s.insert_good(1);
+        assert_eq!(s.last_three, [0, 0, 1]);
+        s.insert_good(2);
+        assert_eq!(s.last_three, [0, 1, 2]);
+        s.insert_good(3);
+        assert_eq!(s.last_three, [1, 2, 3]);
+        s.insert_good(4);
+        assert_eq!(s.last_three, [2, 3, 4]);
+        s.insert_good(1);
+        assert_eq!(s.last_three, [2, 3, 4]);
     }
 }
+
+// // TODO @James: I've already created some of the test cases from
+// // https://github.com/tweedegolf/cfg-noodle/issues/16 in tests/integration_tests.rs
+// // and the tests in this module are mostly obsolete. What is still missing, though, are
+// // unit tests that could be (re)used for fuzzing.
+// // I think we should first decide on entire counter handling before writing these since
+// // the function signatures and output might change. But once that is done, we can gather
+// // a list of tests that should be implemented and we both write some of them.
+// // And we might want to keep in mind that the fuzzer probably wants to reuse some of that code.
+// // In general, we probably must decide on what the interface to the outside looks, first.
+// #[cfg(test)]
+// mod test {
+//     extern crate std;
+//     use super::*;
+
+//     use core::time::Duration;
+//     use minicbor::CborLen;
+//     use mutex::raw_impls::cs::CriticalSectionRawMutex;
+//     use sequential_storage::cache::NoCache;
+//     use sequential_storage::mock_flash::MockFlashBase;
+//     use sequential_storage::mock_flash::WriteCountCheck;
+//     use test_log::test;
+//     use tokio::task::JoinHandle;
+//     use tokio::time::sleep;
+
+//     #[derive(Debug, Encode, Decode, Clone, PartialEq, CborLen)]
+//     struct PositronConfig {
+//         #[n(0)]
+//         up: u8,
+//         #[n(1)]
+//         down: u16,
+//         #[n(2)]
+//         strange: u32,
+//     }
+
+//     impl Default for PositronConfig {
+//         fn default() -> Self {
+//             Self {
+//                 up: 10,
+//                 down: 20,
+//                 strange: 103,
+//             }
+//         }
+//     }
+
+//     // TODO: This type, the get_mock_flash() and worker_task() are not only specific to sequential storage's
+//     // mock flash, but also copy&pasted in the integration tests. If we go with the flash-trait approach,
+//     // these could be generic.
+//     type MockFlash = Flash<MockFlashBase<10, 16, 256>, NoCache>;
+
+//     fn get_mock_flash() -> MockFlash {
+//         let mut flash = MockFlashBase::<10, 16, 256>::new(WriteCountCheck::OnceOnly, None, true);
+//         // TODO: Figure out why miri tests with unaligned buffers and whether
+//         // this needs any fixing. For now just disable the alignment check in MockFlash
+//         flash.alignment_check = false;
+//         Flash::new(flash, 0x0000..0x1000, NoCache::new())
+//     }
+
+//     fn worker_task<R: ScopedRawMutex + Sync>(
+//         list: &'static StorageList<R>,
+//         mut flash: MockFlash,
+//         mut read_buf: [u8; 4096],
+//         mut serde_buf: [u8; 4096],
+//     ) -> JoinHandle<()> {
+//         tokio::task::spawn(async move {
+//             loop {
+//                 info!("worker_task waiting for needs_* signal");
+//                 match embassy_futures::select::select(
+//                     list.needs_read.wait(),
+//                     list.needs_write.wait(),
+//                 )
+//                 .await
+//                 {
+//                     embassy_futures::select::Either::First(_) => {
+//                         info!("worker task got needs_read signal");
+//                         if let Err(e) = list.process_reads(&mut flash, &mut read_buf).await {
+//                             error!("Error in process_reads: {:?}", e);
+//                         }
+//                     }
+//                     embassy_futures::select::Either::Second(_) => {
+//                         info!("worker task got needs_write signal");
+//                         if let Err(e) = list
+//                             .process_writes(&mut flash, &mut read_buf, &mut serde_buf)
+//                             .await
+//                         {
+//                             error!("Error in process_writes: {:?}", e);
+//                         }
+
+//                         info!("Wrote to flash: {}", flash.flash().print_items().await);
+//                     }
+//                 }
+//             }
+//         })
+//     }
+
+//     #[test(tokio::test)]
+//     async fn test_two_configs() {
+//         static GLOBAL_LIST: StorageList<CriticalSectionRawMutex> = StorageList::new();
+//         static POSITRON_CONFIG1: StorageListNode<PositronConfig> =
+//             StorageListNode::new("positron/config1");
+//         static POSITRON_CONFIG2: StorageListNode<PositronConfig> =
+//             StorageListNode::new("positron/config2");
+
+//         let flash = get_mock_flash();
+
+//         let read_buf = [0u8; 4096];
+//         let serde_buf = [0u8; 4096];
+
+//         info!("Spawn worker_task");
+//         let worker_task = worker_task(&GLOBAL_LIST, flash, read_buf, serde_buf);
+
+//         // Obtain a handle for the first config
+//         let config_handle = match POSITRON_CONFIG1.attach(&GLOBAL_LIST).await {
+//             Ok(ch) => ch,
+//             Err(_) => panic!("Could not attach config 1 to list"),
+//         };
+
+//         // Obtain a handle for the second config. This should _not_ error!
+//         if POSITRON_CONFIG2.attach(&GLOBAL_LIST).await.is_err() {
+//             panic!("Could not attach config 2 to list");
+//         }
+
+//         // Load data for the first handle
+//         let data: PositronConfig = config_handle
+//             .load()
+//             .await
+//             .expect("Loading config should not fail");
+//         info!("T3 Got {data:?}");
+
+//         // Assert that the counter is at default value because we
+//         // haven't read this from flash
+//         assert_eq!(
+//             unsafe { config_handle.inner.inner.get().as_ref() }
+//                 .expect("Getting inner at this point should not fail")
+//                 .header
+//                 .counter,
+//             Some(Counter::default())
+//         );
+
+//         // Write a new config to first handle
+//         let new_config = PositronConfig {
+//             up: 15,
+//             down: 25,
+//             strange: 108,
+//         };
+//         config_handle
+//             .write(&new_config)
+//             .await
+//             .expect("Writing config to node should not fail");
+
+//         // Give the worker_task some time to process the write
+//         sleep(Duration::from_millis(100)).await;
+
+//         // Assert that the loaded value equals the written value
+//         assert_eq!(
+//             config_handle
+//                 .load()
+//                 .await
+//                 .expect("Loading config should not fail"),
+//             new_config
+//         );
+
+//         // Assert that the counter is now 1
+//         assert_eq!(
+//             unsafe { config_handle.inner.inner.get().as_ref() }
+//                 .expect("Getting inner at this point should not fail")
+//                 .header
+//                 .counter
+//                 .expect("Counter should have a value at this point"),
+//             Wrapping(1)
+//         );
+
+//         // Wait for the worker task to finish
+//         let _ = tokio::time::timeout(Duration::from_secs(2), worker_task).await;
+//     }
+
+//     #[test(tokio::test)]
+//     async fn test_load_existing() {
+//         // This test will write a config to the flash first and then read it back to check
+//         // whether reading an item from flash works.
+
+//         static GLOBAL_LIST: StorageList<CriticalSectionRawMutex> = StorageList::new();
+//         static POSITRON_CONFIG: StorageListNode<PositronConfig> =
+//             StorageListNode::new("positron/config");
+
+//         let mut serde_buf = [0u8; 4096];
+//         let read_buf = [0u8; 4096];
+
+//         // Serialize the custom_config config so we can write it to our flash
+//         let custom_config = PositronConfig {
+//             up: 1,
+//             down: 22,
+//             strange: 333,
+//         };
+
+//         // TODO: The following pointer operations are a very cumbersome way
+//         // of serializing the node just so we can push it to the flash and read back...
+//         unsafe {
+//             POSITRON_CONFIG
+//                 .inner
+//                 .get()
+//                 .as_mut()
+//                 .expect("Pointer should not be null")
+//                 .t = MaybeUninit::new(custom_config.clone());
+//             POSITRON_CONFIG
+//                 .inner
+//                 .get()
+//                 .as_mut()
+//                 .expect("Pointer should not be null")
+//                 .header
+//                 .counter = Some(Wrapping(0));
+//         }
+//         let nodeptr: *mut Node<PositronConfig> = POSITRON_CONFIG.inner.get();
+//         let nodenn: NonNull<Node<PositronConfig>> = unsafe { NonNull::new_unchecked(nodeptr) };
+//         let hdrnn: NonNull<NodeHeader> = nodenn.cast();
+
+//         let used = serialize_node(hdrnn, &mut serde_buf).expect("Serializing node should not fail");
+
+//         // Now serialize again by calling encode() directly and verify both match
+//         let mut serialize_control = std::vec![];
+//         let len = len_with(&custom_config, &mut ());
+//         minicbor::encode(&custom_config, &mut serialize_control).expect("Encoding should not fail");
+//         // The serialized node will contain some metadata, but the last `len` bytes must match
+//         assert_eq!(serialize_control[..len], serde_buf[used - len..used]);
+
+//         let mut flash = get_mock_flash();
+//         info!("Pushing to flash: {:?}", &serde_buf[..used]);
+//         flash
+//             .push(&serde_buf[..used])
+//             .await
+//             .expect("pushing to flash should not fail here");
+
+//         let worker_task = worker_task(&GLOBAL_LIST, flash, read_buf, serde_buf);
+
+//         // Obtain a handle for the config. It should match the custom_config.
+//         // This should _not_ error!
+//         let expecting_already_present = match POSITRON_CONFIG.attach(&GLOBAL_LIST).await {
+//             Ok(ch) => ch,
+//             Err(_) => panic!("Could not attach config to list"),
+//         };
+
+//         assert_eq!(
+//             custom_config,
+//             expecting_already_present
+//                 .load()
+//                 .await
+//                 .expect("Loading config should not fail"),
+//             "Key should already be present"
+//         );
+
+//         expecting_already_present
+//             .write(&custom_config)
+//             .await
+//             .expect("Writing config to node should not fail");
+
+//         sleep(Duration::from_millis(50)).await;
+
+//         // Assert that the counter is now 1
+//         assert_eq!(
+//             unsafe { expecting_already_present.inner.inner.get().as_ref() }
+//                 .expect("Node should exist")
+//                 .header
+//                 .counter
+//                 .expect("Counter should have a value"),
+//             Wrapping(1)
+//         );
+
+//         // Wait for the worker task to finish
+//         let _ = tokio::time::timeout(Duration::from_secs(2), worker_task).await;
+//     }
+
+//     #[test(tokio::test)]
+//     #[should_panic]
+//     async fn test_duplicate_key() {
+//         static GLOBAL_LIST: StorageList<CriticalSectionRawMutex> = StorageList::new();
+//         static POSITRON_CONFIG1: StorageListNode<PositronConfig> =
+//             StorageListNode::new("positron/config");
+//         static POSITRON_CONFIG2: StorageListNode<PositronConfig> =
+//             StorageListNode::new("positron/config");
+
+//         let flash = get_mock_flash();
+
+//         info!("Spawn worker_task");
+//         let serde_buf = [0u8; 4096];
+//         let read_buf = [0u8; 4096];
+//         let worker_task = worker_task(&GLOBAL_LIST, flash, read_buf, serde_buf);
+
+//         // Obtain a handle for the first config
+//         let _config_handle = match POSITRON_CONFIG1.attach(&GLOBAL_LIST).await {
+//             Ok(ch) => ch,
+//             Err(_) => panic!("Could not attach config 1 to list"),
+//         };
+
+//         // Obtain a handle for the second config. It has the same key as the first.
+//         // This must panic!
+//         let _expecting_panic = POSITRON_CONFIG2.attach(&GLOBAL_LIST).await;
+
+//         // Wait for the worker task to finish
+//         let _ = tokio::time::timeout(Duration::from_secs(2), worker_task).await;
+//     }
+// }

--- a/src/intrusive.rs
+++ b/src/intrusive.rs
@@ -2056,7 +2056,10 @@ mod test {
 
                 // Wait for the worker task to finish
                 stopper.close();
-                let (rd_errs, wr_errs) = tokio::time::timeout(Duration::from_secs(2), worker_task).await.unwrap().unwrap();
+                let (rd_errs, wr_errs) = tokio::time::timeout(Duration::from_secs(2), worker_task)
+                    .await
+                    .unwrap()
+                    .unwrap();
                 assert_eq!(rd_errs, 0);
                 assert_eq!(wr_errs, 0);
             })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 #![deny(clippy::unwrap_used)]
 pub mod error;
 pub mod flash;
-// pub mod intrusive;
+pub mod intrusive;
 
 #[allow(unused)]
 pub(crate) mod logging {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 #![deny(clippy::unwrap_used)]
 pub mod error;
 pub mod flash;
-pub mod intrusive;
+// pub mod intrusive;
 
 #[allow(unused)]
 pub(crate) mod logging {

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,115 +49,115 @@ async fn main() {
     todo!()
 }
 
-fn get_mock_flash() -> Flash<MockFlashBase<10, 16, 256>, NoCache> {
-    let mut flash = MockFlashBase::<10, 16, 256>::new(WriteCountCheck::OnceOnly, None, true);
-    // TODO: Figure out why miri tests with unaligned buffers and whether
-    // this needs any fixing. For now just disable the alignment check in MockFlash
-    flash.alignment_check = false;
-    Flash::new(flash, 0x0000..0x1000, NoCache::new())
-}
+// fn get_mock_flash() -> Flash<MockFlashBase<10, 16, 256>, NoCache> {
+//     let mut flash = MockFlashBase::<10, 16, 256>::new(WriteCountCheck::OnceOnly, None, true);
+//     // TODO: Figure out why miri tests with unaligned buffers and whether
+//     // this needs any fixing. For now just disable the alignment check in MockFlash
+//     flash.alignment_check = false;
+//     Flash::new(flash, 0x0000..0x1000, NoCache::new())
+// }
 
-static GLOBAL_LIST: StorageList<CriticalSectionRawMutex> = StorageList::new();
+// static GLOBAL_LIST: StorageList<CriticalSectionRawMutex> = StorageList::new();
 
-//
-// TASK 1: Has config, but an old version
-//
-#[derive(Debug, Default, Encode, Decode, Clone, CborLen)]
-struct EncabulatorConfigV1 {
-    #[n(0)]
-    polarity: bool,
-}
+// //
+// // TASK 1: Has config, but an old version
+// //
+// #[derive(Debug, Default, Encode, Decode, Clone, CborLen)]
+// struct EncabulatorConfigV1 {
+//     #[n(0)]
+//     polarity: bool,
+// }
 
-#[derive(Debug, Default, Encode, Decode, Clone, CborLen)]
-struct EncabulatorConfigV2 {
-    #[n(0)]
-    polarity: bool,
-    #[n(1)]
-    spinrate: Option<u32>,
-}
+// #[derive(Debug, Default, Encode, Decode, Clone, CborLen)]
+// struct EncabulatorConfigV2 {
+//     #[n(0)]
+//     polarity: bool,
+//     #[n(1)]
+//     spinrate: Option<u32>,
+// }
 
-static ENCAB_CONFIG: StorageListNode<EncabulatorConfigV2> =
-    StorageListNode::new("encabulator/config");
-async fn task_1(list: &'static StorageList<CriticalSectionRawMutex>) {
-    let config_handle = match ENCAB_CONFIG.attach(list).await {
-        Ok(ch) => ch,
-        Err(_) => panic!("Could not attach config to list"),
-    };
-    let data: EncabulatorConfigV2 = config_handle.load().await.unwrap();
-    println!("T1 Got {data:?}");
-    sleep(Duration::from_secs(1)).await;
-    config_handle
-        .write(&EncabulatorConfigV2 {
-            polarity: true,
-            spinrate: Some(100),
-        })
-        .await
-        .unwrap();
-}
+// static ENCAB_CONFIG: StorageListNode<EncabulatorConfigV2> =
+//     StorageListNode::new("encabulator/config");
+// async fn task_1(list: &'static StorageList<CriticalSectionRawMutex>) {
+//     let config_handle = match ENCAB_CONFIG.attach(list).await {
+//         Ok(ch) => ch,
+//         Err(_) => panic!("Could not attach config to list"),
+//     };
+//     let data: EncabulatorConfigV2 = config_handle.load().await.unwrap();
+//     println!("T1 Got {data:?}");
+//     sleep(Duration::from_secs(1)).await;
+//     config_handle
+//         .write(&EncabulatorConfigV2 {
+//             polarity: true,
+//             spinrate: Some(100),
+//         })
+//         .await
+//         .unwrap();
+// }
 
-//
-// TASK 2: Has config, current version
-//
-#[derive(Debug, Default, Encode, Decode, Clone, CborLen)]
-struct GrammeterConfig {
-    #[n(0)]
-    radiation: f32,
-}
+// //
+// // TASK 2: Has config, current version
+// //
+// #[derive(Debug, Default, Encode, Decode, Clone, CborLen)]
+// struct GrammeterConfig {
+//     #[n(0)]
+//     radiation: f32,
+// }
 
-static GRAMM_CONFIG: StorageListNode<GrammeterConfig> = StorageListNode::new("grammeter/config");
-async fn task_2(list: &'static StorageList<CriticalSectionRawMutex>) {
-    let config_handle = match GRAMM_CONFIG.attach(list).await {
-        Ok(ch) => ch,
-        Err(_) => panic!("Could not attach config to list"),
-    };
-    let data: GrammeterConfig = config_handle.load().await.unwrap();
-    println!("T2 Got {data:?}");
-    sleep(Duration::from_secs(3)).await;
-    config_handle
-        .write(&GrammeterConfig { radiation: 200.0 })
-        .await
-        .unwrap();
-}
+// static GRAMM_CONFIG: StorageListNode<GrammeterConfig> = StorageListNode::new("grammeter/config");
+// async fn task_2(list: &'static StorageList<CriticalSectionRawMutex>) {
+//     let config_handle = match GRAMM_CONFIG.attach(list).await {
+//         Ok(ch) => ch,
+//         Err(_) => panic!("Could not attach config to list"),
+//     };
+//     let data: GrammeterConfig = config_handle.load().await.unwrap();
+//     println!("T2 Got {data:?}");
+//     sleep(Duration::from_secs(3)).await;
+//     config_handle
+//         .write(&GrammeterConfig { radiation: 200.0 })
+//         .await
+//         .unwrap();
+// }
 
-//
-// TASK 3: No config
-//
-#[derive(Debug, Encode, Decode, Clone, CborLen)]
-struct PositronConfig {
-    #[n(0)]
-    up: u8,
-    #[n(1)]
-    down: u16,
-    #[n(2)]
-    strange: u32,
-}
+// //
+// // TASK 3: No config
+// //
+// #[derive(Debug, Encode, Decode, Clone, CborLen)]
+// struct PositronConfig {
+//     #[n(0)]
+//     up: u8,
+//     #[n(1)]
+//     down: u16,
+//     #[n(2)]
+//     strange: u32,
+// }
 
-impl Default for PositronConfig {
-    fn default() -> Self {
-        Self {
-            up: 10,
-            down: 20,
-            strange: 103,
-        }
-    }
-}
+// impl Default for PositronConfig {
+//     fn default() -> Self {
+//         Self {
+//             up: 10,
+//             down: 20,
+//             strange: 103,
+//         }
+//     }
+// }
 
-static POSITRON_CONFIG: StorageListNode<PositronConfig> = StorageListNode::new("positron/config");
+// static POSITRON_CONFIG: StorageListNode<PositronConfig> = StorageListNode::new("positron/config");
 
-async fn task_3(list: &'static StorageList<CriticalSectionRawMutex>) {
-    let config_handle = match POSITRON_CONFIG.attach(list).await {
-        Ok(ch) => ch,
-        Err(_) => panic!("Could not attach config to list"),
-    };
-    let data: PositronConfig = config_handle.load().await.unwrap();
-    println!("T3 Got {data:?}");
-    sleep(Duration::from_secs(5)).await;
-    config_handle
-        .write(&PositronConfig {
-            up: 15,
-            down: 25,
-            strange: 108,
-        })
-        .await
-        .unwrap();
-}
+// async fn task_3(list: &'static StorageList<CriticalSectionRawMutex>) {
+//     let config_handle = match POSITRON_CONFIG.attach(list).await {
+//         Ok(ch) => ch,
+//         Err(_) => panic!("Could not attach config to list"),
+//     };
+//     let data: PositronConfig = config_handle.load().await.unwrap();
+//     println!("T3 Got {data:?}");
+//     sleep(Duration::from_secs(5)).await;
+//     config_handle
+//         .write(&PositronConfig {
+//             up: 15,
+//             down: 25,
+//             strange: 108,
+//         })
+//         .await
+//         .unwrap();
+// }

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,10 +37,7 @@ async fn main() {
     for _ in 0..10 {
         sleep(Duration::from_secs(1)).await;
         let mut flash2 = get_mock_flash();
-        if let Err(e) = GLOBAL_LIST
-            .process_writes(&mut flash2, buf)
-            .await
-        {
+        if let Err(e) = GLOBAL_LIST.process_writes(&mut flash2, buf).await {
             error!("Error in process_writes: {:?}", e);
         }
         info!("NEW WRITES: {}", flash2.flash().print_items().await);

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,37 +15,38 @@ use tokio::time::sleep;
 
 #[tokio::main]
 async fn main() {
-    simple_logger::SimpleLogger::new()
-        .without_timestamps()
-        .init()
-        .unwrap();
-    tokio::task::spawn(task_1(&GLOBAL_LIST));
-    tokio::task::spawn(task_2(&GLOBAL_LIST));
-    tokio::task::spawn(task_3(&GLOBAL_LIST));
+    // simple_logger::SimpleLogger::new()
+    //     .without_timestamps()
+    //     .init()
+    //     .unwrap();
+    // tokio::task::spawn(task_1(&GLOBAL_LIST));
+    // tokio::task::spawn(task_2(&GLOBAL_LIST));
+    // tokio::task::spawn(task_3(&GLOBAL_LIST));
 
-    let mut flash = get_mock_flash();
+    // let mut flash = get_mock_flash();
 
-    // give time for tasks to attach
-    sleep(Duration::from_millis(100)).await;
-    // process reads
-    let read_buf = &mut [0u8; 4096];
-    let serde_buf = &mut [0u8; 4096];
-    GLOBAL_LIST
-        .process_reads(&mut flash, read_buf)
-        .await
-        .expect("process_reads failed");
+    // // give time for tasks to attach
+    // sleep(Duration::from_millis(100)).await;
+    // // process reads
+    // let read_buf = &mut [0u8; 4096];
+    // let serde_buf = &mut [0u8; 4096];
+    // GLOBAL_LIST
+    //     .process_reads(&mut flash, read_buf)
+    //     .await
+    //     .expect("process_reads failed");
 
-    for _ in 0..10 {
-        sleep(Duration::from_secs(1)).await;
-        let mut flash2 = get_mock_flash();
-        if let Err(e) = GLOBAL_LIST
-            .process_writes(&mut flash2, read_buf, serde_buf)
-            .await
-        {
-            error!("Error in process_writes: {:?}", e);
-        }
-        info!("NEW WRITES: {}", flash2.flash().print_items().await);
-    }
+    // for _ in 0..10 {
+    //     sleep(Duration::from_secs(1)).await;
+    //     let mut flash2 = get_mock_flash();
+    //     if let Err(e) = GLOBAL_LIST
+    //         .process_writes(&mut flash2, read_buf, serde_buf)
+    //         .await
+    //     {
+    //         error!("Error in process_writes: {:?}", e);
+    //     }
+    //     info!("NEW WRITES: {}", flash2.flash().print_items().await);
+    // }
+    todo!()
 }
 
 fn get_mock_flash() -> Flash<MockFlashBase<10, 16, 256>, NoCache> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,149 +15,148 @@ use tokio::time::sleep;
 
 #[tokio::main]
 async fn main() {
-    // simple_logger::SimpleLogger::new()
-    //     .without_timestamps()
-    //     .init()
-    //     .unwrap();
-    // tokio::task::spawn(task_1(&GLOBAL_LIST));
-    // tokio::task::spawn(task_2(&GLOBAL_LIST));
-    // tokio::task::spawn(task_3(&GLOBAL_LIST));
+    simple_logger::SimpleLogger::new()
+        .without_timestamps()
+        .init()
+        .unwrap();
+    tokio::task::spawn(task_1(&GLOBAL_LIST));
+    tokio::task::spawn(task_2(&GLOBAL_LIST));
+    tokio::task::spawn(task_3(&GLOBAL_LIST));
 
-    // let mut flash = get_mock_flash();
+    let mut flash = get_mock_flash();
 
-    // // give time for tasks to attach
-    // sleep(Duration::from_millis(100)).await;
-    // // process reads
-    // let read_buf = &mut [0u8; 4096];
-    // let serde_buf = &mut [0u8; 4096];
-    // GLOBAL_LIST
-    //     .process_reads(&mut flash, read_buf)
-    //     .await
-    //     .expect("process_reads failed");
+    // give time for tasks to attach
+    sleep(Duration::from_millis(100)).await;
+    // process reads
+    let buf = &mut [0u8; 4096];
+    GLOBAL_LIST
+        .process_reads(&mut flash, buf)
+        .await
+        .expect("process_reads failed");
 
-    // for _ in 0..10 {
-    //     sleep(Duration::from_secs(1)).await;
-    //     let mut flash2 = get_mock_flash();
-    //     if let Err(e) = GLOBAL_LIST
-    //         .process_writes(&mut flash2, read_buf, serde_buf)
-    //         .await
-    //     {
-    //         error!("Error in process_writes: {:?}", e);
-    //     }
-    //     info!("NEW WRITES: {}", flash2.flash().print_items().await);
-    // }
+    for _ in 0..10 {
+        sleep(Duration::from_secs(1)).await;
+        let mut flash2 = get_mock_flash();
+        if let Err(e) = GLOBAL_LIST
+            .process_writes(&mut flash2, buf)
+            .await
+        {
+            error!("Error in process_writes: {:?}", e);
+        }
+        info!("NEW WRITES: {}", flash2.flash().print_items().await);
+    }
     todo!()
 }
 
-// fn get_mock_flash() -> Flash<MockFlashBase<10, 16, 256>, NoCache> {
-//     let mut flash = MockFlashBase::<10, 16, 256>::new(WriteCountCheck::OnceOnly, None, true);
-//     // TODO: Figure out why miri tests with unaligned buffers and whether
-//     // this needs any fixing. For now just disable the alignment check in MockFlash
-//     flash.alignment_check = false;
-//     Flash::new(flash, 0x0000..0x1000, NoCache::new())
-// }
+fn get_mock_flash() -> Flash<MockFlashBase<10, 16, 256>, NoCache> {
+    let mut flash = MockFlashBase::<10, 16, 256>::new(WriteCountCheck::OnceOnly, None, true);
+    // TODO: Figure out why miri tests with unaligned buffers and whether
+    // this needs any fixing. For now just disable the alignment check in MockFlash
+    flash.alignment_check = false;
+    Flash::new(flash, 0x0000..0x1000, NoCache::new())
+}
 
-// static GLOBAL_LIST: StorageList<CriticalSectionRawMutex> = StorageList::new();
+static GLOBAL_LIST: StorageList<CriticalSectionRawMutex> = StorageList::new();
 
-// //
-// // TASK 1: Has config, but an old version
-// //
-// #[derive(Debug, Default, Encode, Decode, Clone, CborLen)]
-// struct EncabulatorConfigV1 {
-//     #[n(0)]
-//     polarity: bool,
-// }
+//
+// TASK 1: Has config, but an old version
+//
+#[derive(Debug, Default, Encode, Decode, Clone, CborLen)]
+struct EncabulatorConfigV1 {
+    #[n(0)]
+    polarity: bool,
+}
 
-// #[derive(Debug, Default, Encode, Decode, Clone, CborLen)]
-// struct EncabulatorConfigV2 {
-//     #[n(0)]
-//     polarity: bool,
-//     #[n(1)]
-//     spinrate: Option<u32>,
-// }
+#[derive(Debug, Default, Encode, Decode, Clone, CborLen)]
+struct EncabulatorConfigV2 {
+    #[n(0)]
+    polarity: bool,
+    #[n(1)]
+    spinrate: Option<u32>,
+}
 
-// static ENCAB_CONFIG: StorageListNode<EncabulatorConfigV2> =
-//     StorageListNode::new("encabulator/config");
-// async fn task_1(list: &'static StorageList<CriticalSectionRawMutex>) {
-//     let config_handle = match ENCAB_CONFIG.attach(list).await {
-//         Ok(ch) => ch,
-//         Err(_) => panic!("Could not attach config to list"),
-//     };
-//     let data: EncabulatorConfigV2 = config_handle.load().await.unwrap();
-//     println!("T1 Got {data:?}");
-//     sleep(Duration::from_secs(1)).await;
-//     config_handle
-//         .write(&EncabulatorConfigV2 {
-//             polarity: true,
-//             spinrate: Some(100),
-//         })
-//         .await
-//         .unwrap();
-// }
+static ENCAB_CONFIG: StorageListNode<EncabulatorConfigV2> =
+    StorageListNode::new("encabulator/config");
+async fn task_1(list: &'static StorageList<CriticalSectionRawMutex>) {
+    let config_handle = match ENCAB_CONFIG.attach(list).await {
+        Ok(ch) => ch,
+        Err(_) => panic!("Could not attach config to list"),
+    };
+    let data: EncabulatorConfigV2 = config_handle.load().await.unwrap();
+    println!("T1 Got {data:?}");
+    sleep(Duration::from_secs(1)).await;
+    config_handle
+        .write(&EncabulatorConfigV2 {
+            polarity: true,
+            spinrate: Some(100),
+        })
+        .await
+        .unwrap();
+}
 
-// //
-// // TASK 2: Has config, current version
-// //
-// #[derive(Debug, Default, Encode, Decode, Clone, CborLen)]
-// struct GrammeterConfig {
-//     #[n(0)]
-//     radiation: f32,
-// }
+//
+// TASK 2: Has config, current version
+//
+#[derive(Debug, Default, Encode, Decode, Clone, CborLen)]
+struct GrammeterConfig {
+    #[n(0)]
+    radiation: f32,
+}
 
-// static GRAMM_CONFIG: StorageListNode<GrammeterConfig> = StorageListNode::new("grammeter/config");
-// async fn task_2(list: &'static StorageList<CriticalSectionRawMutex>) {
-//     let config_handle = match GRAMM_CONFIG.attach(list).await {
-//         Ok(ch) => ch,
-//         Err(_) => panic!("Could not attach config to list"),
-//     };
-//     let data: GrammeterConfig = config_handle.load().await.unwrap();
-//     println!("T2 Got {data:?}");
-//     sleep(Duration::from_secs(3)).await;
-//     config_handle
-//         .write(&GrammeterConfig { radiation: 200.0 })
-//         .await
-//         .unwrap();
-// }
+static GRAMM_CONFIG: StorageListNode<GrammeterConfig> = StorageListNode::new("grammeter/config");
+async fn task_2(list: &'static StorageList<CriticalSectionRawMutex>) {
+    let config_handle = match GRAMM_CONFIG.attach(list).await {
+        Ok(ch) => ch,
+        Err(_) => panic!("Could not attach config to list"),
+    };
+    let data: GrammeterConfig = config_handle.load().await.unwrap();
+    println!("T2 Got {data:?}");
+    sleep(Duration::from_secs(3)).await;
+    config_handle
+        .write(&GrammeterConfig { radiation: 200.0 })
+        .await
+        .unwrap();
+}
 
-// //
-// // TASK 3: No config
-// //
-// #[derive(Debug, Encode, Decode, Clone, CborLen)]
-// struct PositronConfig {
-//     #[n(0)]
-//     up: u8,
-//     #[n(1)]
-//     down: u16,
-//     #[n(2)]
-//     strange: u32,
-// }
+//
+// TASK 3: No config
+//
+#[derive(Debug, Encode, Decode, Clone, CborLen)]
+struct PositronConfig {
+    #[n(0)]
+    up: u8,
+    #[n(1)]
+    down: u16,
+    #[n(2)]
+    strange: u32,
+}
 
-// impl Default for PositronConfig {
-//     fn default() -> Self {
-//         Self {
-//             up: 10,
-//             down: 20,
-//             strange: 103,
-//         }
-//     }
-// }
+impl Default for PositronConfig {
+    fn default() -> Self {
+        Self {
+            up: 10,
+            down: 20,
+            strange: 103,
+        }
+    }
+}
 
-// static POSITRON_CONFIG: StorageListNode<PositronConfig> = StorageListNode::new("positron/config");
+static POSITRON_CONFIG: StorageListNode<PositronConfig> = StorageListNode::new("positron/config");
 
-// async fn task_3(list: &'static StorageList<CriticalSectionRawMutex>) {
-//     let config_handle = match POSITRON_CONFIG.attach(list).await {
-//         Ok(ch) => ch,
-//         Err(_) => panic!("Could not attach config to list"),
-//     };
-//     let data: PositronConfig = config_handle.load().await.unwrap();
-//     println!("T3 Got {data:?}");
-//     sleep(Duration::from_secs(5)).await;
-//     config_handle
-//         .write(&PositronConfig {
-//             up: 15,
-//             down: 25,
-//             strange: 108,
-//         })
-//         .await
-//         .unwrap();
-// }
+async fn task_3(list: &'static StorageList<CriticalSectionRawMutex>) {
+    let config_handle = match POSITRON_CONFIG.attach(list).await {
+        Ok(ch) => ch,
+        Err(_) => panic!("Could not attach config to list"),
+    };
+    let data: PositronConfig = config_handle.load().await.unwrap();
+    println!("T3 Got {data:?}");
+    sleep(Duration::from_secs(5)).await;
+    config_handle
+        .write(&PositronConfig {
+            up: 15,
+            down: 25,
+            strange: 108,
+        })
+        .await
+        .unwrap();
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,443 +1,443 @@
-use cfg_noodle::{
-    flash::Flash,
-    intrusive::{StorageList, StorageListNode},
-};
-use log::{error, info, warn};
-use minicbor::{CborLen, Decode, Encode};
-use mutex::{ScopedRawMutex, raw_impls::cs::CriticalSectionRawMutex};
-use sequential_storage::{
-    cache::NoCache,
-    mock_flash::{MockFlashBase, WriteCountCheck},
-};
-use test_log::test;
-use tokio::{
-    sync::watch::{self, Receiver},
-    task::JoinHandle,
-    time::{Duration, sleep},
-};
+// use cfg_noodle::{
+//     flash::Flash,
+//     intrusive::{StorageList, StorageListNode},
+// };
+// use log::{error, info, warn};
+// use minicbor::{CborLen, Decode, Encode};
+// use mutex::{ScopedRawMutex, raw_impls::cs::CriticalSectionRawMutex};
+// use sequential_storage::{
+//     cache::NoCache,
+//     mock_flash::{MockFlashBase, WriteCountCheck},
+// };
+// use test_log::test;
+// use tokio::{
+//     sync::watch::{self, Receiver},
+//     task::JoinHandle,
+//     time::{Duration, sleep},
+// };
 
-// Scratch buffer size
-const BUF_LEN: usize = 1024;
+// // Scratch buffer size
+// const BUF_LEN: usize = 1024;
 
-#[derive(Debug, Default, Encode, Decode, Clone, CborLen, PartialEq)]
-struct TestConfig {
-    #[n(0)]
-    value: u32,
-    #[n(1)]
-    truth: bool,
-    #[n(2)]
-    optional_truth: Option<bool>,
-}
+// #[derive(Debug, Default, Encode, Decode, Clone, CborLen, PartialEq)]
+// struct TestConfig {
+//     #[n(0)]
+//     value: u32,
+//     #[n(1)]
+//     truth: bool,
+//     #[n(2)]
+//     optional_truth: Option<bool>,
+// }
 
-#[derive(Debug, Default, Encode, Decode, Clone, CborLen)]
-struct SimpleConfig {
-    #[n(0)]
-    data: u8,
-}
+// #[derive(Debug, Default, Encode, Decode, Clone, CborLen)]
+// struct SimpleConfig {
+//     #[n(0)]
+//     data: u8,
+// }
 
-type MockFlash = Flash<MockFlashBase<10, 16, 256>, NoCache>;
+// type MockFlash = Flash<MockFlashBase<10, 16, 256>, NoCache>;
 
-/// Creates a test flash instance with mock storage for testing purposes.
-fn get_test_flash() -> MockFlash {
-    let mut flash = MockFlashBase::<10, 16, 256>::new(WriteCountCheck::Twice, None, true);
-    flash.alignment_check = false;
-    Flash::new(flash, 0x0000..0x1000, NoCache::new())
-}
+// /// Creates a test flash instance with mock storage for testing purposes.
+// fn get_test_flash() -> MockFlash {
+//     let mut flash = MockFlashBase::<10, 16, 256>::new(WriteCountCheck::Twice, None, true);
+//     flash.alignment_check = false;
+//     Flash::new(flash, 0x0000..0x1000, NoCache::new())
+// }
 
-/// Spawns an asynchronous worker task that manages storage operations for a storage list.
-///
-/// This function creates a background task that continuously monitors for read and write requests
-/// from the storage list and processes them against the provided flash storage. The worker task
-/// runs in a loop, waiting for signals from the storage list and handling them appropriately.
-///
-/// # Parameters
-///
-/// * `list` - A static reference to the storage list that manages configuration nodes
-/// * `flash` - The flash storage instance used for persistent storage operations
-/// * `kill_signal` - An optional receiver for graceful task termination. If None, the task
-///   will use a timeout-based approach for periodic checks (10 seconds)
-///
-/// # Returns
-///
-/// Returns a `JoinHandle` that resolves to the flash instance when the worker task terminates.
-/// This allows the caller to recover the flash storage for reuse after task shutdown.
-///
-/// # Behavior
-///
-/// The worker task continuously waits for one of three events:
-/// 1. Read requests from the storage list
-/// 2. Write requests from the storage list
-/// 3. Termination signal or timeout
-///
-/// When a read or write request is received, the task processes it using the appropriate
-/// storage list method. The task terminates gracefully when a kill signal is received,
-/// returning the flash instance to the caller.
-fn worker_task<R: ScopedRawMutex + Sync>(
-    list: &'static StorageList<R>,
-    mut flash: MockFlash,
-    mut kill_signal: Option<Receiver<()>>,
-) -> JoinHandle<MockFlash> {
-    // Clear any pending default value from the kill signal receiver to ensure
-    // we only respond to new termination signals sent after task startup
-    if let Some(rx) = kill_signal.as_mut() {
-        rx.borrow_and_update();
-    }
+// /// Spawns an asynchronous worker task that manages storage operations for a storage list.
+// ///
+// /// This function creates a background task that continuously monitors for read and write requests
+// /// from the storage list and processes them against the provided flash storage. The worker task
+// /// runs in a loop, waiting for signals from the storage list and handling them appropriately.
+// ///
+// /// # Parameters
+// ///
+// /// * `list` - A static reference to the storage list that manages configuration nodes
+// /// * `flash` - The flash storage instance used for persistent storage operations
+// /// * `kill_signal` - An optional receiver for graceful task termination. If None, the task
+// ///   will use a timeout-based approach for periodic checks (10 seconds)
+// ///
+// /// # Returns
+// ///
+// /// Returns a `JoinHandle` that resolves to the flash instance when the worker task terminates.
+// /// This allows the caller to recover the flash storage for reuse after task shutdown.
+// ///
+// /// # Behavior
+// ///
+// /// The worker task continuously waits for one of three events:
+// /// 1. Read requests from the storage list
+// /// 2. Write requests from the storage list
+// /// 3. Termination signal or timeout
+// ///
+// /// When a read or write request is received, the task processes it using the appropriate
+// /// storage list method. The task terminates gracefully when a kill signal is received,
+// /// returning the flash instance to the caller.
+// fn worker_task<R: ScopedRawMutex + Sync>(
+//     list: &'static StorageList<R>,
+//     mut flash: MockFlash,
+//     mut kill_signal: Option<Receiver<()>>,
+// ) -> JoinHandle<MockFlash> {
+//     // Clear any pending default value from the kill signal receiver to ensure
+//     // we only respond to new termination signals sent after task startup
+//     if let Some(rx) = kill_signal.as_mut() {
+//         rx.borrow_and_update();
+//     }
 
-    // Allocate buffers for storage operations - these are reused across operations
-    // to avoid repeated allocations in the async task loop
-    let mut read_buf = [0u8; BUF_LEN]; // Buffer for reading data from flash
-    let mut serde_buf = [0u8; BUF_LEN]; // Buffer for serialization/deserialization
+//     // Allocate buffers for storage operations - these are reused across operations
+//     // to avoid repeated allocations in the async task loop
+//     let mut read_buf = [0u8; BUF_LEN]; // Buffer for reading data from flash
+//     let mut serde_buf = [0u8; BUF_LEN]; // Buffer for serialization/deserialization
 
-    tokio::task::spawn(async move {
-        loop {
-            info!("worker_task waiting for needs_* signal");
+//     tokio::task::spawn(async move {
+//         loop {
+//             info!("worker_task waiting for needs_* signal");
 
-            // Wait for one of three possible events using embassy's select3:
-            // 1. Storage list needs read operations
-            // 2. Storage list needs write operations
-            // 3. Termination signal or periodic timeout
-            match embassy_futures::select::select3(
-                list.needs_read().wait(),
-                list.needs_write().wait(),
-                async {
-                    if let Some(signal) = kill_signal.as_mut() {
-                        // Wait for explicit termination signal
-                        signal.changed().await
-                    } else {
-                        // No kill signal provided, use periodic timeout as fallback
-                        sleep(Duration::from_secs(10)).await;
-                        Ok(())
-                    }
-                },
-            )
-            .await
-            {
-                // Handle read request from storage list
-                embassy_futures::select::Either3::First(_) => {
-                    info!("worker task got needs_read signal");
-                    if let Err(e) = list.process_reads(&mut flash, &mut read_buf).await {
-                        error!("Error in process_reads: {:?}", e);
-                    }
-                }
-                // Handle write request from storage list
-                embassy_futures::select::Either3::Second(_) => {
-                    info!("worker task got needs_write signal");
-                    // Process writes and handle any errors that occur during the operation
-                    if let Err(e) = list
-                        .process_writes(&mut flash, &mut read_buf, &mut serde_buf)
-                        .await
-                    {
-                        error!("Error in process_writes: {:?}", e);
-                    }
-                }
-                // Handle termination signal or timeout - exit the loop and return flash
-                embassy_futures::select::Either3::Third(_) => return flash,
-            }
-        }
-    })
-}
+//             // Wait for one of three possible events using embassy's select3:
+//             // 1. Storage list needs read operations
+//             // 2. Storage list needs write operations
+//             // 3. Termination signal or periodic timeout
+//             match embassy_futures::select::select3(
+//                 list.needs_read().wait(),
+//                 list.needs_write().wait(),
+//                 async {
+//                     if let Some(signal) = kill_signal.as_mut() {
+//                         // Wait for explicit termination signal
+//                         signal.changed().await
+//                     } else {
+//                         // No kill signal provided, use periodic timeout as fallback
+//                         sleep(Duration::from_secs(10)).await;
+//                         Ok(())
+//                     }
+//                 },
+//             )
+//             .await
+//             {
+//                 // Handle read request from storage list
+//                 embassy_futures::select::Either3::First(_) => {
+//                     info!("worker task got needs_read signal");
+//                     if let Err(e) = list.process_reads(&mut flash, &mut read_buf).await {
+//                         error!("Error in process_reads: {:?}", e);
+//                     }
+//                 }
+//                 // Handle write request from storage list
+//                 embassy_futures::select::Either3::Second(_) => {
+//                     info!("worker task got needs_write signal");
+//                     // Process writes and handle any errors that occur during the operation
+//                     if let Err(e) = list
+//                         .process_writes(&mut flash, &mut read_buf, &mut serde_buf)
+//                         .await
+//                     {
+//                         error!("Error in process_writes: {:?}", e);
+//                     }
+//                 }
+//                 // Handle termination signal or timeout - exit the loop and return flash
+//                 embassy_futures::select::Either3::Third(_) => return flash,
+//             }
+//         }
+//     })
+// }
 
-/// Test that verifies the storage system returns default configuration values when reading from empty flash.
-///
-/// This test validates the basic behavior of the storage system when no configuration data has been
-/// previously written to flash storage. It creates a fresh flash instance without any data and
-/// attempts to load configuration from it.
-///
-/// The test demonstrates that:
-/// 1. The storage system can handle empty flash storage gracefully
-/// 2. When no configuration data exists, the system returns the default configuration values
-/// 3. The storage initialization and worker task startup work correctly with empty flash
-///
-/// This validates the expected fallback behavior for first-time system startup or after
-/// flash memory has been completely erased.
-#[test(tokio::test)]
-async fn test_read_from_empty_flash() {
-    info!("Starting test");
-    static LIST: StorageList<CriticalSectionRawMutex> = StorageList::new();
-    static NODE: StorageListNode<TestConfig> = StorageListNode::new("test/config");
+// /// Test that verifies the storage system returns default configuration values when reading from empty flash.
+// ///
+// /// This test validates the basic behavior of the storage system when no configuration data has been
+// /// previously written to flash storage. It creates a fresh flash instance without any data and
+// /// attempts to load configuration from it.
+// ///
+// /// The test demonstrates that:
+// /// 1. The storage system can handle empty flash storage gracefully
+// /// 2. When no configuration data exists, the system returns the default configuration values
+// /// 3. The storage initialization and worker task startup work correctly with empty flash
+// ///
+// /// This validates the expected fallback behavior for first-time system startup or after
+// /// flash memory has been completely erased.
+// #[test(tokio::test)]
+// async fn test_read_from_empty_flash() {
+//     info!("Starting test");
+//     static LIST: StorageList<CriticalSectionRawMutex> = StorageList::new();
+//     static NODE: StorageListNode<TestConfig> = StorageListNode::new("test/config");
 
-    // Create flash but do not populate with any data
-    let flash = get_test_flash();
+//     // Create flash but do not populate with any data
+//     let flash = get_test_flash();
 
-    info!("Spawning worker task");
-    let _worker = worker_task(&LIST, flash, None);
+//     info!("Spawning worker task");
+//     let _worker = worker_task(&LIST, flash, None);
 
-    let handle = NODE.attach(&LIST).await.unwrap();
+//     let handle = NODE.attach(&LIST).await.unwrap();
 
-    // Should return default value
-    let config = handle.load().await.unwrap();
-    let default_config = TestConfig::default();
-    assert_eq!(
-        config, default_config,
-        "Loaded config should match default config"
-    );
-}
+//     // Should return default value
+//     let config = handle.load().await.unwrap();
+//     let default_config = TestConfig::default();
+//     assert_eq!(
+//         config, default_config,
+//         "Loaded config should match default config"
+//     );
+// }
 
-/// Test that verifies configuration persistence across simulated system restarts.
-///
-/// This test writes a configuration to flash storage, then simulates a system restart
-/// by creating a new storage list and node. It verifies that the previously written
-/// configuration is correctly loaded from flash storage after the restart.
-///
-/// The test demonstrates that:
-/// 1. Configuration data is properly persisted to flash storage
-/// 2. The storage system can recover configuration data after a restart
-/// 3. Data integrity is maintained across storage system lifecycle events
-#[test(tokio::test)]
-async fn test_read_clean_state() {
-    static LIST: StorageList<CriticalSectionRawMutex> = StorageList::new();
-    static NODE: StorageListNode<TestConfig> = StorageListNode::new("test/config");
+// /// Test that verifies configuration persistence across simulated system restarts.
+// ///
+// /// This test writes a configuration to flash storage, then simulates a system restart
+// /// by creating a new storage list and node. It verifies that the previously written
+// /// configuration is correctly loaded from flash storage after the restart.
+// ///
+// /// The test demonstrates that:
+// /// 1. Configuration data is properly persisted to flash storage
+// /// 2. The storage system can recover configuration data after a restart
+// /// 3. Data integrity is maintained across storage system lifecycle events
+// #[test(tokio::test)]
+// async fn test_read_clean_state() {
+//     static LIST: StorageList<CriticalSectionRawMutex> = StorageList::new();
+//     static NODE: StorageListNode<TestConfig> = StorageListNode::new("test/config");
 
-    let flash = get_test_flash();
-    info!("Spawning worker task");
-    let (tx, rx) = watch::channel(());
-    let worker = worker_task(&LIST, flash, Some(rx));
+//     let flash = get_test_flash();
+//     info!("Spawning worker task");
+//     let (tx, rx) = watch::channel(());
+//     let worker = worker_task(&LIST, flash, Some(rx));
 
-    let handle = NODE.attach(&LIST).await.unwrap();
+//     let handle = NODE.attach(&LIST).await.unwrap();
 
-    let test_config = TestConfig {
-        value: 42,
-        truth: false,
-        optional_truth: Some(true),
-    };
-    handle.write(&test_config).await.unwrap();
+//     let test_config = TestConfig {
+//         value: 42,
+//         truth: false,
+//         optional_truth: Some(true),
+//     };
+//     handle.write(&test_config).await.unwrap();
 
-    // Give worker time to process the write
-    sleep(Duration::from_millis(100)).await;
+//     // Give worker time to process the write
+//     sleep(Duration::from_millis(100)).await;
 
-    // Stop worker task and save the flash data it produced
-    tx.send(()).unwrap();
-    let mut flash = worker.await.unwrap();
+//     // Stop worker task and save the flash data it produced
+//     tx.send(()).unwrap();
+//     let mut flash = worker.await.unwrap();
 
-    // Create new list and node to simulate restart
-    static LIST2: StorageList<CriticalSectionRawMutex> = StorageList::new();
-    static NODE2: StorageListNode<TestConfig> = StorageListNode::new("test/config");
+//     // Create new list and node to simulate restart
+//     static LIST2: StorageList<CriticalSectionRawMutex> = StorageList::new();
+//     static NODE2: StorageListNode<TestConfig> = StorageListNode::new("test/config");
 
-    info!(
-        "Spawning new worker with flash content: {}",
-        flash.flash().print_items().await
-    );
-    // Spawn worker task with the used flash
-    let _worker = worker_task(&LIST2, flash, None);
+//     info!(
+//         "Spawning new worker with flash content: {}",
+//         flash.flash().print_items().await
+//     );
+//     // Spawn worker task with the used flash
+//     let _worker = worker_task(&LIST2, flash, None);
 
-    let handle2 = NODE2.attach(&LIST2).await.unwrap();
+//     let handle2 = NODE2.attach(&LIST2).await.unwrap();
 
-    let loaded_config = handle2.load().await.unwrap();
-    assert_eq!(
-        loaded_config, test_config,
-        "Loaded config should match test_config"
-    );
-}
+//     let loaded_config = handle2.load().await.unwrap();
+//     assert_eq!(
+//         loaded_config, test_config,
+//         "Loaded config should match test_config"
+//     );
+// }
 
-/// Test that verifies config persistence across restarts and proper handling of multiple configs.
-///
-/// This test writes a config to one node, simulates a system restart by creating new storage lists
-/// and nodes, then verifies that:
-/// 1. The previously written config is correctly loaded from flash storage
-/// 2. A newly added config node returns default values becauseno data exists for it
-///
-/// The test demonstrates that the storage system can handle multiple configuration nodes
-/// independently and maintain data integrity across restarts.
-#[test(tokio::test)]
-async fn test_read_clean_state_new_config() {
-    static LIST: StorageList<CriticalSectionRawMutex> = StorageList::new();
-    static NODE: StorageListNode<TestConfig> = StorageListNode::new("test/config1");
+// /// Test that verifies config persistence across restarts and proper handling of multiple configs.
+// ///
+// /// This test writes a config to one node, simulates a system restart by creating new storage lists
+// /// and nodes, then verifies that:
+// /// 1. The previously written config is correctly loaded from flash storage
+// /// 2. A newly added config node returns default values becauseno data exists for it
+// ///
+// /// The test demonstrates that the storage system can handle multiple configuration nodes
+// /// independently and maintain data integrity across restarts.
+// #[test(tokio::test)]
+// async fn test_read_clean_state_new_config() {
+//     static LIST: StorageList<CriticalSectionRawMutex> = StorageList::new();
+//     static NODE: StorageListNode<TestConfig> = StorageListNode::new("test/config1");
 
-    let flash = get_test_flash();
-    info!("Spawning worker task");
-    let (tx, rx) = watch::channel(());
-    let worker = worker_task(&LIST, flash, Some(rx));
+//     let flash = get_test_flash();
+//     info!("Spawning worker task");
+//     let (tx, rx) = watch::channel(());
+//     let worker = worker_task(&LIST, flash, Some(rx));
 
-    let handle = NODE.attach(&LIST).await.unwrap();
+//     let handle = NODE.attach(&LIST).await.unwrap();
 
-    let test_config = TestConfig {
-        value: 42,
-        truth: false,
-        optional_truth: Some(true),
-    };
-    handle.write(&test_config).await.unwrap();
+//     let test_config = TestConfig {
+//         value: 42,
+//         truth: false,
+//         optional_truth: Some(true),
+//     };
+//     handle.write(&test_config).await.unwrap();
 
-    // Give worker time to process the write
-    sleep(Duration::from_millis(100)).await;
+//     // Give worker time to process the write
+//     sleep(Duration::from_millis(100)).await;
 
-    // Stop worker task and save the flash data it produced
-    tx.send(()).unwrap();
-    let mut flash = worker.await.unwrap();
+//     // Stop worker task and save the flash data it produced
+//     tx.send(()).unwrap();
+//     let mut flash = worker.await.unwrap();
 
-    // Create new list and node to simulate restart
-    static LIST2: StorageList<CriticalSectionRawMutex> = StorageList::new();
-    static NODE1: StorageListNode<TestConfig> = StorageListNode::new("test/config1");
-    static NODE2: StorageListNode<TestConfig> = StorageListNode::new("test/config2");
+//     // Create new list and node to simulate restart
+//     static LIST2: StorageList<CriticalSectionRawMutex> = StorageList::new();
+//     static NODE1: StorageListNode<TestConfig> = StorageListNode::new("test/config1");
+//     static NODE2: StorageListNode<TestConfig> = StorageListNode::new("test/config2");
 
-    info!(
-        "Spawning new worker with flash content: {}",
-        flash.flash().print_items().await
-    );
-    // Spawn worker task with the used flash
-    let _worker = worker_task(&LIST2, flash, None);
+//     info!(
+//         "Spawning new worker with flash content: {}",
+//         flash.flash().print_items().await
+//     );
+//     // Spawn worker task with the used flash
+//     let _worker = worker_task(&LIST2, flash, None);
 
-    let handle1 = NODE1.attach(&LIST2).await.unwrap();
-    let handle2 = NODE2.attach(&LIST2).await.unwrap();
+//     let handle1 = NODE1.attach(&LIST2).await.unwrap();
+//     let handle2 = NODE2.attach(&LIST2).await.unwrap();
 
-    let loaded_config1 = handle1.load().await.unwrap();
-    let loaded_config2 = handle2.load().await.unwrap();
-    assert_eq!(
-        loaded_config1, test_config,
-        "Loaded config should match the test_config"
-    );
-    assert_eq!(
-        loaded_config2,
-        TestConfig::default(),
-        "Loaded config should match default config"
-    );
-}
+//     let loaded_config1 = handle1.load().await.unwrap();
+//     let loaded_config2 = handle2.load().await.unwrap();
+//     assert_eq!(
+//         loaded_config1, test_config,
+//         "Loaded config should match the test_config"
+//     );
+//     assert_eq!(
+//         loaded_config2,
+//         TestConfig::default(),
+//         "Loaded config should match default config"
+//     );
+// }
 
-/// Test that verifies the storage system's resilience to interrupted writes and flash corruption.
-///
-/// This test simulates a scenario where flash storage becomes partially corrupted during or after
-/// a write operation. It writes configurations to two separate nodes, then deliberately corrupts
-/// part of the flash memory by filling bytes with 0xFF (simulating an interrupted erase/write cycle).
-///
-/// The test demonstrates that:
-/// 1. The storage system can handle partial flash corruption gracefully
-/// 2. Uncorrupted configuration data remains accessible after corruption occurs
-/// 3. Corrupted configuration nodes fall back to default values appropriately
-/// 4. Multiple configuration nodes can coexist with different corruption states
-///
-/// This validates the robustness of the storage system against real-world scenarios where
-/// power loss or other interruptions could corrupt flash memory during write operations.
-#[test(tokio::test)]
-async fn test_read_interrupted_write() {
-    static LIST: StorageList<CriticalSectionRawMutex> = StorageList::new();
-    static NODE1: StorageListNode<TestConfig> = StorageListNode::new("test/config1");
-    static NODE2: StorageListNode<TestConfig> = StorageListNode::new("test/config2");
+// /// Test that verifies the storage system's resilience to interrupted writes and flash corruption.
+// ///
+// /// This test simulates a scenario where flash storage becomes partially corrupted during or after
+// /// a write operation. It writes configurations to two separate nodes, then deliberately corrupts
+// /// part of the flash memory by filling bytes with 0xFF (simulating an interrupted erase/write cycle).
+// ///
+// /// The test demonstrates that:
+// /// 1. The storage system can handle partial flash corruption gracefully
+// /// 2. Uncorrupted configuration data remains accessible after corruption occurs
+// /// 3. Corrupted configuration nodes fall back to default values appropriately
+// /// 4. Multiple configuration nodes can coexist with different corruption states
+// ///
+// /// This validates the robustness of the storage system against real-world scenarios where
+// /// power loss or other interruptions could corrupt flash memory during write operations.
+// #[test(tokio::test)]
+// async fn test_read_interrupted_write() {
+//     static LIST: StorageList<CriticalSectionRawMutex> = StorageList::new();
+//     static NODE1: StorageListNode<TestConfig> = StorageListNode::new("test/config1");
+//     static NODE2: StorageListNode<TestConfig> = StorageListNode::new("test/config2");
 
-    let flash = get_test_flash();
-    info!("Spawning worker task");
-    let (tx, rx) = watch::channel(());
-    let worker = worker_task(&LIST, flash, Some(rx));
+//     let flash = get_test_flash();
+//     info!("Spawning worker task");
+//     let (tx, rx) = watch::channel(());
+//     let worker = worker_task(&LIST, flash, Some(rx));
 
-    let handle1 = NODE1.attach(&LIST).await.unwrap();
-    let handle2 = NODE2.attach(&LIST).await.unwrap();
-    let test_config2 = TestConfig {
-        value: 1,
-        truth: true,
-        optional_truth: Some(true),
-    };
-    handle1
-        .write(&TestConfig {
-            value: 2,
-            truth: false,
-            optional_truth: Some(false),
-        })
-        .await
-        .unwrap();
-    handle2.write(&test_config2).await.unwrap();
+//     let handle1 = NODE1.attach(&LIST).await.unwrap();
+//     let handle2 = NODE2.attach(&LIST).await.unwrap();
+//     let test_config2 = TestConfig {
+//         value: 1,
+//         truth: true,
+//         optional_truth: Some(true),
+//     };
+//     handle1
+//         .write(&TestConfig {
+//             value: 2,
+//             truth: false,
+//             optional_truth: Some(false),
+//         })
+//         .await
+//         .unwrap();
+//     handle2.write(&test_config2).await.unwrap();
 
-    // Write the two nodes to the list
-    LIST.needs_write().wake_all();
+//     // Write the two nodes to the list
+//     LIST.needs_write().wake_all();
 
-    // Give worker time to process the write
-    sleep(Duration::from_millis(100)).await;
+//     // Give worker time to process the write
+//     sleep(Duration::from_millis(100)).await;
 
-    // Stop worker task and save the flash data it produced
-    tx.send(()).unwrap();
-    let mut flash = worker.await.unwrap();
+//     // Stop worker task and save the flash data it produced
+//     tx.send(()).unwrap();
+//     let mut flash = worker.await.unwrap();
 
-    warn!("Set some bytes in flash to zero");
-    warn!("Flash before: {}", flash.flash().print_items().await);
-    let flash_bytes = flash.flash().as_bytes_mut();
-    // at byte 48 the 2nd item starts (may need to be adapted! check the print_items output)
-    // The second item seems to be the first node, so this relies on knowing what the layout in flash is
-    // TODO: improve how the flash is partly erased...
-    flash_bytes[48..].fill(0xFF);
+//     warn!("Set some bytes in flash to zero");
+//     warn!("Flash before: {}", flash.flash().print_items().await);
+//     let flash_bytes = flash.flash().as_bytes_mut();
+//     // at byte 48 the 2nd item starts (may need to be adapted! check the print_items output)
+//     // The second item seems to be the first node, so this relies on knowing what the layout in flash is
+//     // TODO: improve how the flash is partly erased...
+//     flash_bytes[48..].fill(0xFF);
 
-    warn!("Flash after: {}", flash.flash().print_items().await);
+//     warn!("Flash after: {}", flash.flash().print_items().await);
 
-    // Create new list and node to simulate restart
-    static LIST2: StorageList<CriticalSectionRawMutex> = StorageList::new();
+//     // Create new list and node to simulate restart
+//     static LIST2: StorageList<CriticalSectionRawMutex> = StorageList::new();
 
-    static NODE1_2: StorageListNode<TestConfig> = StorageListNode::new("test/config1");
-    static NODE2_2: StorageListNode<TestConfig> = StorageListNode::new("test/config2");
+//     static NODE1_2: StorageListNode<TestConfig> = StorageListNode::new("test/config1");
+//     static NODE2_2: StorageListNode<TestConfig> = StorageListNode::new("test/config2");
 
-    info!("Spawning new worker task");
-    // Spawn worker task with the used flash
-    let _worker = worker_task(&LIST2, flash, None);
+//     info!("Spawning new worker task");
+//     // Spawn worker task with the used flash
+//     let _worker = worker_task(&LIST2, flash, None);
 
-    let handle1 = NODE1_2.attach(&LIST2).await.unwrap();
-    let handle2 = NODE2_2.attach(&LIST2).await.unwrap();
+//     let handle1 = NODE1_2.attach(&LIST2).await.unwrap();
+//     let handle2 = NODE2_2.attach(&LIST2).await.unwrap();
 
-    let loaded_config1 = handle1.load().await.unwrap();
-    let loaded_config2 = handle2.load().await.unwrap();
-    assert_eq!(
-        loaded_config1,
-        TestConfig::default(),
-        "Loaded config1 should match default config (was zeroed before)"
-    );
-    assert_eq!(
-        loaded_config2, test_config2,
-        "Loaded config1 should match test_config"
-    );
-}
+//     let loaded_config1 = handle1.load().await.unwrap();
+//     let loaded_config2 = handle2.load().await.unwrap();
+//     assert_eq!(
+//         loaded_config1,
+//         TestConfig::default(),
+//         "Loaded config1 should match default config (was zeroed before)"
+//     );
+//     assert_eq!(
+//         loaded_config2, test_config2,
+//         "Loaded config1 should match test_config"
+//     );
+// }
 
-/// Test that verifies the storage system's handling of multiple writes to the same configuration node.
-///
-/// This test performs two consecutive writes of identical configuration data to a single node and
-/// verifies that the storage system correctly manages flash storage entries by cleaning up old data.
-/// The test validates that:
-/// 1. The first write creates initial flash entries for the configuration
-/// 2. The second write of the same configuration data is handled properly
-/// 3. After the second successful write, the old configuration entries are automatically deleted
-/// 4. Only the expected number of flash entries remain (one for the current node and one for write confirmation)
-///
-/// The test demonstrates that the storage system efficiently manages flash space by removing
-/// obsolete entries after successful writes, preventing flash storage from accumulating
-/// unnecessary duplicate configuration data over multiple write operations.
-#[test(tokio::test)]
-async fn test_multiple_writes() {
-    static LIST: StorageList<CriticalSectionRawMutex> = StorageList::new();
-    static NODE: StorageListNode<TestConfig> = StorageListNode::new("test/config");
+// /// Test that verifies the storage system's handling of multiple writes to the same configuration node.
+// ///
+// /// This test performs two consecutive writes of identical configuration data to a single node and
+// /// verifies that the storage system correctly manages flash storage entries by cleaning up old data.
+// /// The test validates that:
+// /// 1. The first write creates initial flash entries for the configuration
+// /// 2. The second write of the same configuration data is handled properly
+// /// 3. After the second successful write, the old configuration entries are automatically deleted
+// /// 4. Only the expected number of flash entries remain (one for the current node and one for write confirmation)
+// ///
+// /// The test demonstrates that the storage system efficiently manages flash space by removing
+// /// obsolete entries after successful writes, preventing flash storage from accumulating
+// /// unnecessary duplicate configuration data over multiple write operations.
+// #[test(tokio::test)]
+// async fn test_multiple_writes() {
+//     static LIST: StorageList<CriticalSectionRawMutex> = StorageList::new();
+//     static NODE: StorageListNode<TestConfig> = StorageListNode::new("test/config");
 
-    let flash = get_test_flash();
+//     let flash = get_test_flash();
 
-    info!("Spawning worker task");
-    let (tx, rx) = watch::channel(());
-    let worker = worker_task(&LIST, flash, Some(rx));
+//     info!("Spawning worker task");
+//     let (tx, rx) = watch::channel(());
+//     let worker = worker_task(&LIST, flash, Some(rx));
 
-    let handle = NODE.attach(&LIST).await.unwrap();
+//     let handle = NODE.attach(&LIST).await.unwrap();
 
-    let test_config = TestConfig {
-        value: 42,
-        truth: false,
-        optional_truth: Some(true),
-    };
-    // Write the config for the first time
-    handle.write(&test_config).await.unwrap();
+//     let test_config = TestConfig {
+//         value: 42,
+//         truth: false,
+//         optional_truth: Some(true),
+//     };
+//     // Write the config for the first time
+//     handle.write(&test_config).await.unwrap();
 
-    // Give worker time to process the write
-    sleep(Duration::from_millis(100)).await;
+//     // Give worker time to process the write
+//     sleep(Duration::from_millis(100)).await;
 
-    // Write again. This should delete the old nodes when write was successful.
-    handle.write(&test_config).await.unwrap();
+//     // Write again. This should delete the old nodes when write was successful.
+//     handle.write(&test_config).await.unwrap();
 
-    // Give worker time to process the write
-    sleep(Duration::from_millis(100)).await;
+//     // Give worker time to process the write
+//     sleep(Duration::from_millis(100)).await;
 
-    // Stop worker task and save the flash data it produced
-    tx.send(()).unwrap();
-    let mut flash = worker.await.unwrap();
+//     // Stop worker task and save the flash data it produced
+//     tx.send(()).unwrap();
+//     let mut flash = worker.await.unwrap();
 
-    info!("Flash content: {}", flash.flash().print_items().await);
+//     info!("Flash content: {}", flash.flash().print_items().await);
 
-    // Iterate over the flash and count the number of items
-    let mut iter = flash.iter().await.unwrap();
-    let mut item_counter = 0;
-    while iter.next(&mut [0u8; BUF_LEN]).await.unwrap().is_some() {
-        item_counter += 1;
-    }
-    info!("Found {} items in flash (expecting 2).", item_counter);
-    assert_eq!(
-        item_counter, 2,
-        "expected 2 items in the flash (one node and one write_confirm)"
-    )
-}
+//     // Iterate over the flash and count the number of items
+//     let mut iter = flash.iter().await.unwrap();
+//     let mut item_counter = 0;
+//     while iter.next(&mut [0u8; BUF_LEN]).await.unwrap().is_some() {
+//         item_counter += 1;
+//     }
+//     info!("Found {} items in flash (expecting 2).", item_counter);
+//     assert_eq!(
+//         item_counter, 2,
+//         "expected 2 items in the flash (one node and one write_confirm)"
+//     )
+// }


### PR DESCRIPTION
This is a fairly large PR, but in broad strokes, it:

* Introduces the trait described by #25
* Implements the behavior and "data format" described by #25
    * One note: we are now able to store the whole path as the key, instead of just a hash
* Implements a non-sequential-storage based test impl of the trait, allowing for more direct testing

There is probably some polish missing, but this is now approaching "close enough to review".

The trait lifetimes got ROUGH, and due to that, I ended up needing to compromise on some interface niceness, but I was able to make it okay-ish with some macros. End-users won't see this grossness, only folks that try to implement the trait, and if they use the blanket sequential-storage impl: they won't ever need to touch it.

Also as a note, I had hoped at least the test impl of the trait would be `Send`, but there are still issues (cc https://github.com/rust-lang/rust/issues/100013), so I've switched to just using `LocalSet` for all testing to not require `Send` in testing.

Tagging @diondokter for real review, cc'ing @JuliDi for awareness.