### PR TITLE
Implement Garbage Collection of old/bad elements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,7 +154,6 @@ version = "0.1.0"
 dependencies = [
  "approx",
  "arbitrary",
- "const-fnv1a-hash",
  "cordyceps",
  "crc",
  "critical-section",
@@ -189,12 +188,6 @@ dependencies = [
  "lazy_static",
  "windows-sys 0.59.0",
 ]
-
-[[package]]
-name = "const-fnv1a-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b13ea120a812beba79e34316b3942a857c86ec1593cb34f27bb28272ce2cca"
 
 [[package]]
 name = "cordyceps"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ defmt = ["dep:defmt", "sequential-storage/defmt-03"]
 arbitrary = ["dep:arbitrary"]
 
 [dependencies]
-const-fnv1a-hash = "1.1.0"
 embedded-storage-async = "0.4.1"
 minicbor = { version = "1.0.0", features = ["derive"] }
 sequential-storage = "4.0.1"

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,7 +9,7 @@ pub enum Error {
     Deserialization,
     /// Serializing a node into the buffer failed
     Serialization,
-    /// The key hash already exists in the list
+    /// The key already exists in the list
     DuplicateKey,
     /// Recoverable error to tell the caller that the list needs reading first.
     NeedsFirstRead,
@@ -19,7 +19,7 @@ pub enum Error {
     /// running out of space.
     NeedsGarbageCollect,
     /// Node is in a state that is invalid at the particular point of operation.
-    /// Contains a tuple of the node key hash and the state that was deemed invalid.
+    /// Contains a tuple of the node key and the state that was deemed invalid.
     InvalidState(&'static str, State),
     /// The flash returned inconsistent data between iterations. This is likely fatal.
     InconsistentFlash,

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,6 +24,8 @@ pub enum Error {
     /// Node is in a state that is invalid at the particular point of operation.
     /// Contains a tuple of the node key hash and the state that was deemed invalid.
     InvalidState(&'static str, State),
+    /// The flash returned inconsistent data between iterations. This is likely fatal.
+    InconsistentFlash,
 }
 
 #[derive(Debug)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,9 +17,6 @@ pub enum Error {
     /// collection before doing writes. In some cases, this might not be necessary,
     /// but for now we force it after the first read and after every write to avoid
     /// running out of space.
-    ///
-    /// In the future, we could only require this if we hit the end of the list when
-    /// actually performing a write.
     NeedsGarbageCollect,
     /// Node is in a state that is invalid at the particular point of operation.
     /// Contains a tuple of the node key hash and the state that was deemed invalid.

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,7 +12,15 @@ pub enum Error {
     /// The key hash already exists in the list
     DuplicateKey,
     /// Recoverable error to tell the caller that the list needs reading first.
-    NeedsRead,
+    NeedsFirstRead,
+    /// Recoverable error to tell the caller that the list needs to process garbage
+    /// collection before doing writes. In some cases, this might not be necessary,
+    /// but for now we force it after the first read and after every write to avoid
+    /// running out of space.
+    ///
+    /// In the future, we could only require this if we hit the end of the list when
+    /// actually performing a write.
+    NeedsGarbageCollect,
     /// Node is in a state that is invalid at the particular point of operation.
     /// Contains a tuple of the node key hash and the state that was deemed invalid.
     InvalidState(&'static str, State),
@@ -24,8 +32,6 @@ pub enum Error {
 ///
 /// Sometimes specific to the flash implementation.
 pub enum LoadStoreError<T> {
-    /// Needs Initial read processed
-    NeedsFirstRead,
     /// Writing to flash has failed. Contains the error returned by the storage impl.
     FlashWrite(T),
     /// Reading from flash has failed. Contains the error returned by the storage impl.

--- a/src/flash.rs
+++ b/src/flash.rs
@@ -36,7 +36,14 @@ pub struct FlashNode<'flash, 'iter, 'buf, T: MultiwriteNorFlash, C: CacheImpl> {
 /// A partially decoded element
 ///
 /// This is a helper type that mimics [`Elem`], so we don't need to re-decode it
-/// on every access.
+/// on every access. HalfElem is called that because it's a "half parsed [`Elem`]"
+///
+/// If we parse out good start/end data, we just store that so we don't have to keep reloading it
+/// If it's a data elem, we just check that the discriminant is right, but we don't store it,
+/// we just remember that the slice of data that we have is a data slice, and we use that
+/// when we create the real [`Elem`].
+///
+/// This is a trick to not re-parse the raw data every time we call `.data()`.
 #[derive(Clone, Copy)]
 enum HalfElem {
     Start { seq_no: NonZeroU32 },

--- a/src/flash.rs
+++ b/src/flash.rs
@@ -161,7 +161,9 @@ impl<T: MultiwriteNorFlash, C: CacheImpl> NdlElemIterNode for FlashNode<'_, '_, 
         Some(match *half {
             HalfElem::Start { seq_no } => Elem::Start { seq_no },
             HalfElem::Data => Elem::Data {
-                data: SerData::from_existing(self.qit.deref()).unwrap(),
+                // NOTE: IF HalfElem decoded successfully (and we have a Some(HalfElem)), then the
+                // SerData creation must ALWAYS be valid (they check the same header).
+                data: SerData::from_existing(self.qit.deref())?,
             },
             HalfElem::End { seq_no, calc_crc } => Elem::End { seq_no, calc_crc },
         })

--- a/src/storage_list.rs
+++ b/src/storage_list.rs
@@ -342,11 +342,11 @@ impl<R: ScopedRawMutex> StorageList<R> {
             core::mem::take(&mut guard.seq_state)
         };
 
-        // Helper function that iterates over each present GoodRecord,
-        // and returns whether ANY of the good records contain this index
+        // Helper function that iterates over each present GoodWriteRecord,
+        // and returns whether ANY of the good records contain this iterator-index
         //
         // TODO: ensure none of the good items are overlapping?
-        let meta_contains = |n: usize| {
+        let last_three_contains = |n: usize| {
             cur_seq_state
                 .last_three
                 .iter()
@@ -373,7 +373,7 @@ impl<R: ScopedRawMutex> StorageList<R> {
 
             // If it doesn't decode: yeet
             // If it's not in a good range: yeet
-            if next.data().is_none() || !meta_contains(this_idx) {
+            if next.data().is_none() || !last_three_contains(this_idx) {
                 next.invalidate()
                     .await
                     .map_err(LoadStoreError::FlashWrite)?;

--- a/src/storage_list.rs
+++ b/src/storage_list.rs
@@ -478,7 +478,9 @@ impl StorageListInner {
             // What kind of data is this?
             match item.data() {
                 None => {
-                    // badly decoded data
+                    // badly decoded data - if we're in the middle of a maybe-good
+                    // record, invalidate it.
+                    current = None;
                     continue;
                 }
                 // A start node: discard any current state, and start reading this

--- a/src/storage_list.rs
+++ b/src/storage_list.rs
@@ -442,7 +442,7 @@ impl StorageListInner {
     ///
     /// Returns:
     ///
-    /// - `Ok(Some(seq))` - This is the highest valid seen sequence number
+    /// - `Ok(Some(rpt))` - The most recent valid Write Record (as a [`GoodWriteRecord`])
     /// - `Ok(None)` - The storage contains NO valid write records
     /// - `Err(e)` - An error while accessing storage
     async fn get_or_populate_latest<S: NdlDataStorage>(

--- a/src/storage_list.rs
+++ b/src/storage_list.rs
@@ -475,7 +475,12 @@ impl StorageListInner {
                     if calc_crc != check_crc {
                         continue;
                     }
-                    debug!("Good found seq: {}, range {}..={}", u32::from(seq_no), start_idx, idx);
+                    debug!(
+                        "Good found seq: {}, range {}..={}",
+                        u32::from(seq_no),
+                        start_idx,
+                        idx
+                    );
                     self.seq_state.insert_good(GoodWriteRecord {
                         seq: seq_no,
                         range: start_idx..=idx,
@@ -516,7 +521,7 @@ impl StorageListInner {
         // that we end up at the sequence number that we expect.
         for _ in 0..*latest.range.start() {
             match queue_iter.next(buf).await {
-                Ok(Some(_item)) => {},
+                Ok(Some(_item)) => {}
                 Ok(None) => return Err(LoadStoreError::AppError(Error::InconsistentFlash)),
                 Err(e) => return Err(LoadStoreError::FlashRead(e)),
             }
@@ -552,9 +557,12 @@ impl StorageListInner {
                 // Got data: great!
                 Some(Elem::Data { data }) => data,
                 // Got end: if it's the one we expect, great!
-                Some(Elem::End { seq_no, calc_crc: _ }) if seq_no == latest.seq => {
+                Some(Elem::End {
+                    seq_no,
+                    calc_crc: _,
+                }) if seq_no == latest.seq => {
                     break;
-                },
+                }
                 // If we reached the end of the list, OR a new start, OR an end for the wrong
                 // sequence number, that is bad, because this is SUPPOSED to be a pre-validated
                 // write record. Something has gone very wrong.
@@ -613,7 +621,10 @@ impl StorageListInner {
                     // actually be useful.
                     //
                     // todo: add logs? some kind of asserts?
-                    warn!("Key {:?} exists and was wanted, but deserialization failed", kvpair.key);
+                    warn!(
+                        "Key {:?} exists and was wanted, but deserialization failed",
+                        kvpair.key
+                    );
                     hdrmut.state = State::NonResident;
                 }
             }

--- a/src/storage_list.rs
+++ b/src/storage_list.rs
@@ -475,7 +475,7 @@ impl StorageListInner {
                     if calc_crc != check_crc {
                         continue;
                     }
-                    debug!("Good found seq: {seq_no}, range {start_idx}..={idx}");
+                    debug!("Good found seq: {}, range {}..={}", u32::from(seq_no), start_idx, idx);
                     self.seq_state.insert_good(GoodWriteRecord {
                         seq: seq_no,
                         range: start_idx..=idx,

--- a/src/storage_node.rs
+++ b/src/storage_node.rs
@@ -223,7 +223,7 @@ where
     /// returned in the second element of the Result::Error tuple.
     ///
     /// # Panics
-    /// This function will panic if a node with the same key(-hash) already
+    /// This function will panic if a node with the same key already
     /// exists in the list.
     ///
     /// TODO: Re-evaluate the panicking behavior and whether or not to return

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -385,7 +385,7 @@ pub async fn worker_task_seq_sto<R: ScopedRawMutex + Sync>(
                     if let Err(e) = list.process_garbage(&mut flash, &mut buf).await {
                         error!("Error in process_garbage: {:?}", e);
                     } else {
-                        first_gc_done = false;
+                        first_gc_done = true;
                     }
                 }
             }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -111,6 +111,7 @@ impl TestStorage {
     /// Print all items contained by this TestStorage
     pub fn print_items(&self) -> String {
         let mut out = String::new();
+        out.push('\n');
         for i in self.items.iter() {
             writeln!(&mut out, "- (ctr: {}): {:?}", i.ctr, i.elem).unwrap();
         }

--- a/tests/bad_gc_stress.rs
+++ b/tests/bad_gc_stress.rs
@@ -1,0 +1,135 @@
+#![cfg_attr(miri, allow(dead_code, unused_imports))]
+
+use std::{num::NonZeroU32, sync::Arc};
+
+use cfg_noodle::{StorageList, StorageListNode};
+use maitake_sync::WaitQueue;
+use minicbor::{CborLen, Decode, Encode};
+use mutex::raw_impls::cs::CriticalSectionRawMutex;
+use tokio::task::{yield_now, LocalSet};
+use cfg_noodle::test_utils::{TestStorage, worker_task_tst_sto, worker_task_tst_sto_custom, TestItem, TestElem};
+use test_log::test;
+
+#[derive(Debug, Default, Encode, Decode, Clone, CborLen, PartialEq)]
+struct SimpleConfig {
+    #[n(0)]
+    data: u64,
+}
+
+#[test(tokio::test)]
+async fn bad_gc_stress() {
+    let local = LocalSet::new();
+    local
+        .run_until(bad_gc_stress_inner())
+        .await;
+}
+
+async fn bad_gc_stress_inner() {
+    let mut flash = TestStorage::default();
+
+    // add a bunch of bad elements
+    flash.add_data_elem::<SimpleConfig>(
+        "test/configx",
+        &SimpleConfig { data: 1 },
+        None,
+    );
+    flash.start_write_record(NonZeroU32::new(4).unwrap());
+    flash.add_data_elem::<SimpleConfig>(
+        "test/configx",
+        &SimpleConfig { data: 2 },
+        None,
+    );
+    flash.start_write_record(NonZeroU32::new(5).unwrap());
+    flash.end_write_record(NonZeroU32::new(4).unwrap(), 1234);
+
+    // add one that is ALMOST good but with a bad CRC
+    let mut wr = flash.start_write_record(NonZeroU32::new(5).unwrap());
+    wr.add_data_elem("test/config1", &SimpleConfig { data: 3 });
+    wr.add_data_elem("test/config2", &SimpleConfig { data: 4 });
+    wr.add_data_elem("test/config3", &SimpleConfig { data: 5 });
+    wr.end_write_record();
+    {
+        let item = flash.items.last_mut().unwrap();
+        let TestElem::End { seq_no, calc_crc } = item.elem.as_mut().unwrap() else {
+            panic!()
+        };
+        *calc_crc = !*calc_crc;
+    }
+
+    // add a good record, aliases with the almost-good item!
+    let mut wr = flash.start_write_record(NonZeroU32::new(5).unwrap());
+    wr.add_data_elem("test/config1", &SimpleConfig { data: 13 });
+    wr.add_data_elem("test/config2", &SimpleConfig { data: 14 });
+    wr.add_data_elem("test/config3", &SimpleConfig { data: 15 });
+    wr.end_write_record();
+
+    // Add another bad item
+    let mut wr = flash.start_write_record(NonZeroU32::new(6).unwrap());
+    wr.add_data_elem("test/config1", &SimpleConfig { data: 23 });
+    wr.add_data_elem("test/config2", &SimpleConfig { data: 24 });
+    wr.add_data_elem("test/config3", &SimpleConfig { data: 25 });
+    wr.end_write_record();
+    {
+        let item = flash.items.last_mut().unwrap();
+        let TestElem::End { seq_no, calc_crc } = item.elem.as_mut().unwrap() else {
+            panic!()
+        };
+        *calc_crc = !*calc_crc;
+    }
+
+    // add a bunch of bad elements
+    flash.add_data_elem::<SimpleConfig>(
+        "test/configx",
+        &SimpleConfig { data: 1 },
+        None,
+    );
+    flash.start_write_record(NonZeroU32::new(4).unwrap());
+    flash.add_data_elem::<SimpleConfig>(
+        "test/configx",
+        &SimpleConfig { data: 2 },
+        None,
+    );
+    flash.start_write_record(NonZeroU32::new(5).unwrap());
+    flash.end_write_record(NonZeroU32::new(4).unwrap(), 1234);
+
+    // add a good record, aliases with the almost-good item!
+    let mut wr = flash.start_write_record(NonZeroU32::new(6).unwrap());
+    wr.add_data_elem("test/config1", &SimpleConfig { data: 33 });
+    wr.add_data_elem("test/config2", &SimpleConfig { data: 34 });
+    wr.add_data_elem("test/config3", &SimpleConfig { data: 35 });
+    wr.end_write_record();
+
+    // and finally a bunch more bad elements
+    flash.add_data_elem::<SimpleConfig>(
+        "test/configx",
+        &SimpleConfig { data: 1 },
+        None,
+    );
+    flash.start_write_record(NonZeroU32::new(4).unwrap());
+    flash.add_data_elem::<SimpleConfig>(
+        "test/configx",
+        &SimpleConfig { data: 2 },
+        None,
+    );
+    flash.start_write_record(NonZeroU32::new(5).unwrap());
+    flash.end_write_record(NonZeroU32::new(4).unwrap(), 1234);
+
+    static LIST: StorageList<CriticalSectionRawMutex> = StorageList::new();
+    static NODE_A: StorageListNode<SimpleConfig> = StorageListNode::new("test/config1");
+    static NODE_B: StorageListNode<SimpleConfig> = StorageListNode::new("test/config2");
+    static NODE_C: StorageListNode<SimpleConfig> = StorageListNode::new("test/config3");
+
+    let stopper = Arc::new(WaitQueue::new());
+    let hdl = tokio::task::spawn_local(worker_task_tst_sto_custom(&LIST, stopper.clone(), flash));
+
+    let node_a = NODE_A.attach(&LIST).await.unwrap();
+    let node_b = NODE_B.attach(&LIST).await.unwrap();
+    let node_c = NODE_C.attach(&LIST).await.unwrap();
+
+    assert_eq!(node_a.load().await.unwrap().data, 33);
+    assert_eq!(node_b.load().await.unwrap().data, 34);
+    assert_eq!(node_c.load().await.unwrap().data, 35);
+
+    // yield to ensure initial gc has a chance to run
+    yield_now().await;
+}

--- a/tests/bad_gc_stress.rs
+++ b/tests/bad_gc_stress.rs
@@ -2,13 +2,13 @@
 
 use std::{num::NonZeroU32, sync::Arc};
 
+use cfg_noodle::test_utils::{TestElem, TestItem, TestStorage, worker_task_tst_sto_custom};
 use cfg_noodle::{StorageList, StorageListNode};
 use maitake_sync::WaitQueue;
 use minicbor::{CborLen, Decode, Encode};
 use mutex::raw_impls::cs::CriticalSectionRawMutex;
-use tokio::task::{yield_now, LocalSet};
-use cfg_noodle::test_utils::{TestStorage, worker_task_tst_sto_custom, TestElem, TestItem};
 use test_log::test;
+use tokio::task::{LocalSet, yield_now};
 
 #[derive(Debug, Default, Encode, Decode, Clone, CborLen, PartialEq)]
 struct SimpleConfig {
@@ -19,26 +19,16 @@ struct SimpleConfig {
 #[test(tokio::test)]
 async fn bad_gc_stress() {
     let local = LocalSet::new();
-    local
-        .run_until(bad_gc_stress_inner())
-        .await;
+    local.run_until(bad_gc_stress_inner()).await;
 }
 
 async fn bad_gc_stress_inner() {
     let mut flash = TestStorage::default();
 
     // add a bunch of bad elements
-    flash.add_data_elem::<SimpleConfig>(
-        "test/configx",
-        &SimpleConfig { data: 1 },
-        None,
-    );
+    flash.add_data_elem::<SimpleConfig>("test/configx", &SimpleConfig { data: 1 }, None);
     flash.start_write_record(NonZeroU32::new(4).unwrap());
-    flash.add_data_elem::<SimpleConfig>(
-        "test/configx",
-        &SimpleConfig { data: 2 },
-        None,
-    );
+    flash.add_data_elem::<SimpleConfig>("test/configx", &SimpleConfig { data: 2 }, None);
     flash.start_write_record(NonZeroU32::new(5).unwrap());
     flash.end_write_record(NonZeroU32::new(4).unwrap(), 1234);
 
@@ -50,7 +40,11 @@ async fn bad_gc_stress_inner() {
     wr.end_write_record();
     {
         let item = flash.items.last_mut().unwrap();
-        let TestElem::End { seq_no: _, calc_crc } = item.elem.as_mut().unwrap() else {
+        let TestElem::End {
+            seq_no: _,
+            calc_crc,
+        } = item.elem.as_mut().unwrap()
+        else {
             panic!()
         };
         *calc_crc = !*calc_crc;
@@ -71,24 +65,20 @@ async fn bad_gc_stress_inner() {
     wr.end_write_record();
     {
         let item = flash.items.last_mut().unwrap();
-        let TestElem::End { seq_no: _, calc_crc } = item.elem.as_mut().unwrap() else {
+        let TestElem::End {
+            seq_no: _,
+            calc_crc,
+        } = item.elem.as_mut().unwrap()
+        else {
             panic!()
         };
         *calc_crc = !*calc_crc;
     }
 
     // add a bunch of bad elements
-    flash.add_data_elem::<SimpleConfig>(
-        "test/configx",
-        &SimpleConfig { data: 1 },
-        None,
-    );
+    flash.add_data_elem::<SimpleConfig>("test/configx", &SimpleConfig { data: 1 }, None);
     flash.start_write_record(NonZeroU32::new(4).unwrap());
-    flash.add_data_elem::<SimpleConfig>(
-        "test/configx",
-        &SimpleConfig { data: 2 },
-        None,
-    );
+    flash.add_data_elem::<SimpleConfig>("test/configx", &SimpleConfig { data: 2 }, None);
     flash.start_write_record(NonZeroU32::new(5).unwrap());
     flash.end_write_record(NonZeroU32::new(4).unwrap(), 1234);
 
@@ -100,17 +90,9 @@ async fn bad_gc_stress_inner() {
     wr.end_write_record();
 
     // and finally a bunch more bad elements
-    flash.add_data_elem::<SimpleConfig>(
-        "test/configx",
-        &SimpleConfig { data: 1 },
-        None,
-    );
+    flash.add_data_elem::<SimpleConfig>("test/configx", &SimpleConfig { data: 1 }, None);
     flash.start_write_record(NonZeroU32::new(4).unwrap());
-    flash.add_data_elem::<SimpleConfig>(
-        "test/configx",
-        &SimpleConfig { data: 2 },
-        None,
-    );
+    flash.add_data_elem::<SimpleConfig>("test/configx", &SimpleConfig { data: 2 }, None);
     flash.start_write_record(NonZeroU32::new(5).unwrap());
     flash.end_write_record(NonZeroU32::new(4).unwrap(), 1234);
 

--- a/tests/gc_handles_bad_contents.rs
+++ b/tests/gc_handles_bad_contents.rs
@@ -122,6 +122,9 @@ async fn gc_handles_bad_contents_inner() {
     let rpt = hdl.await.unwrap();
     rpt.assert_no_errs();
 
+    // This is a general snapshot test that ensures that we end up with the two records
+    // that we expect, and none of the garbage, meaning that `process_garbage` has removed
+    // everything that is not reasonable data.
     #[rustfmt::skip]
     let expected: &[_] = &[
         TestItem { ctr: 10, elem: Some(TestElem::Start { seq_no: NonZeroU32::new(5).unwrap() }) },

--- a/tests/gc_handles_bad_contents.rs
+++ b/tests/gc_handles_bad_contents.rs
@@ -17,12 +17,16 @@ struct SimpleConfig {
 }
 
 #[test(tokio::test)]
-async fn bad_gc_stress() {
+async fn gc_handles_bad_contents() {
     let local = LocalSet::new();
-    local.run_until(bad_gc_stress_inner()).await;
+    local.run_until(gc_handles_bad_contents_inner()).await;
 }
 
-async fn bad_gc_stress_inner() {
+/// A test that fills the flash with lots of garbage among a few good records
+///
+/// We check that this is handled correctly, and the GC algo leaves us with only the
+/// valid Write Records we care about.
+async fn gc_handles_bad_contents_inner() {
     let mut flash = TestStorage::default();
 
     // add a bunch of bad elements

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -295,12 +295,12 @@ async fn test_read_interrupted_write() {
             let mut iter = flash.items.iter_mut();
             loop {
                 let item = iter.next().unwrap();
-                if matches!(item.elem, TestElem::Start { seq_no } if seq_no == NonZeroU32::new(2).unwrap()) {
+                if matches!(item.elem, Some(TestElem::Start { seq_no }) if seq_no == NonZeroU32::new(2).unwrap()) {
                     break;
                 }
             }
             let item = iter.next().unwrap();
-            let TestElem::Data { data } = &mut item.elem else {
+            let Some(TestElem::Data { data }) = &mut item.elem else {
                 panic!();
             };
             *data.get_mut(3).unwrap() = 0xFF;

--- a/tests/many_good_writes.rs
+++ b/tests/many_good_writes.rs
@@ -2,12 +2,12 @@
 
 use std::{num::NonZeroU32, sync::Arc};
 
+use cfg_noodle::test_utils::{TestElem, TestItem, worker_task_tst_sto, worker_task_tst_sto_custom};
 use cfg_noodle::{StorageList, StorageListNode};
 use maitake_sync::WaitQueue;
 use minicbor::{CborLen, Decode, Encode};
 use mutex::raw_impls::cs::CriticalSectionRawMutex;
-use tokio::task::{yield_now, LocalSet};
-use cfg_noodle::test_utils::{worker_task_tst_sto, worker_task_tst_sto_custom, TestItem, TestElem};
+use tokio::task::{LocalSet, yield_now};
 
 #[derive(Debug, Default, Encode, Decode, Clone, CborLen, PartialEq)]
 struct SimpleConfig {
@@ -20,9 +20,7 @@ struct SimpleConfig {
 #[cfg(not(miri))]
 async fn many_good_writes() {
     let local = LocalSet::new();
-    local
-        .run_until(many_good_writes_inner())
-        .await;
+    local.run_until(many_good_writes_inner()).await;
 }
 
 async fn many_good_writes_inner() {
@@ -89,7 +87,11 @@ async fn many_good_writes_inner() {
     static NODE_C2: StorageListNode<SimpleConfig> = StorageListNode::new("test/config3");
 
     let stopper = Arc::new(WaitQueue::new());
-    let hdl = tokio::task::spawn_local(worker_task_tst_sto_custom(&LIST2, stopper.clone(), rpt.flash));
+    let hdl = tokio::task::spawn_local(worker_task_tst_sto_custom(
+        &LIST2,
+        stopper.clone(),
+        rpt.flash,
+    ));
 
     let node_a = NODE_A2.attach(&LIST2).await.unwrap();
     let node_b = NODE_B2.attach(&LIST2).await.unwrap();
@@ -116,7 +118,11 @@ async fn many_good_writes_inner() {
     static NODE_C3: StorageListNode<SimpleConfig> = StorageListNode::new("test/config3");
 
     let stopper = Arc::new(WaitQueue::new());
-    let hdl = tokio::task::spawn_local(worker_task_tst_sto_custom(&LIST3, stopper.clone(), rpt.flash));
+    let hdl = tokio::task::spawn_local(worker_task_tst_sto_custom(
+        &LIST3,
+        stopper.clone(),
+        rpt.flash,
+    ));
 
     let node_a = NODE_A3.attach(&LIST3).await.unwrap();
     let node_b = NODE_B3.attach(&LIST3).await.unwrap();

--- a/tests/many_good_writes.rs
+++ b/tests/many_good_writes.rs
@@ -1,0 +1,167 @@
+#![cfg_attr(miri, allow(dead_code, unused_imports))]
+
+use std::{num::NonZeroU32, sync::Arc};
+
+use cfg_noodle::{StorageList, StorageListNode};
+use maitake_sync::WaitQueue;
+use minicbor::{CborLen, Decode, Encode};
+use mutex::raw_impls::cs::CriticalSectionRawMutex;
+use tokio::task::{yield_now, LocalSet};
+use cfg_noodle::test_utils::{worker_task_tst_sto, worker_task_tst_sto_custom, TestItem, TestElem};
+
+#[derive(Debug, Default, Encode, Decode, Clone, CborLen, PartialEq)]
+struct SimpleConfig {
+    #[n(0)]
+    data: u64,
+}
+
+// Test runs a bit slow to reasonably run in miri
+#[tokio::test]
+#[cfg(not(miri))]
+async fn many_good_writes() {
+    let local = LocalSet::new();
+    local
+        .run_until(many_good_writes_inner())
+        .await;
+}
+
+async fn many_good_writes_inner() {
+    static LIST: StorageList<CriticalSectionRawMutex> = StorageList::new();
+    static NODE_A: StorageListNode<SimpleConfig> = StorageListNode::new("test/config1");
+    static NODE_B: StorageListNode<SimpleConfig> = StorageListNode::new("test/config2");
+    static NODE_C: StorageListNode<SimpleConfig> = StorageListNode::new("test/config3");
+
+    let stopper = Arc::new(WaitQueue::new());
+    let hdl = tokio::task::spawn_local(worker_task_tst_sto(&LIST, stopper.clone()));
+
+    let node_a = NODE_A.attach(&LIST).await.unwrap();
+    let node_b = NODE_B.attach(&LIST).await.unwrap();
+    let node_c = NODE_C.attach(&LIST).await.unwrap();
+
+    assert_eq!(node_a.load().await.unwrap().data, 0);
+    assert_eq!(node_b.load().await.unwrap().data, 0);
+    assert_eq!(node_c.load().await.unwrap().data, 0);
+
+    // yield to ensure initial gc has a chance to run
+    yield_now().await;
+
+    for i in 1..1000 {
+        node_a.write(&SimpleConfig { data: i }).await.unwrap();
+        node_b.write(&SimpleConfig { data: i * 10 }).await.unwrap();
+        node_c.write(&SimpleConfig { data: i * 100 }).await.unwrap();
+        // yield to allow writing and gc to take place
+        yield_now().await;
+    }
+
+    stopper.close();
+    let rpt = hdl.await.unwrap();
+    rpt.assert_no_errs();
+
+    let contents = &rpt.flash.items;
+    #[rustfmt::skip]
+    let expected = &[
+        // Oldest item, seq_no 997
+        TestItem { ctr: 4980, elem: Some(TestElem::Start { seq_no: NonZeroU32::new(997).unwrap() }) },
+            TestItem { ctr: 4981, elem: Some(TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 51, 129, 26, 0, 1, 133, 116] }) },
+            TestItem { ctr: 4982, elem: Some(TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 50, 129, 25, 38, 242] }) },
+            TestItem { ctr: 4983, elem: Some(TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 49, 129, 25, 3, 229] }) },
+        TestItem { ctr: 4984, elem: Some(TestElem::End { seq_no: NonZeroU32::new(997).unwrap(), calc_crc: 2789166760 }) },
+        // Middle item, seq_no 998
+        TestItem { ctr: 4985, elem: Some(TestElem::Start { seq_no: NonZeroU32::new(998).unwrap() }) },
+            TestItem { ctr: 4986, elem: Some(TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 51, 129, 26, 0, 1, 133, 216] }) },
+            TestItem { ctr: 4987, elem: Some(TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 50, 129, 25, 38, 252] }) },
+            TestItem { ctr: 4988, elem: Some(TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 49, 129, 25, 3, 230] }) },
+        TestItem { ctr: 4989, elem: Some(TestElem::End { seq_no: NonZeroU32::new(998).unwrap(), calc_crc: 1413754379 }) },
+        // Newest item, seq_no 999
+        TestItem { ctr: 4990, elem: Some(TestElem::Start { seq_no: NonZeroU32::new(999).unwrap() }) },
+            TestItem { ctr: 4991, elem: Some(TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 51, 129, 26, 0, 1, 134, 60] }) },
+            TestItem { ctr: 4992, elem: Some(TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 50, 129, 25, 39, 6] }) },
+            TestItem { ctr: 4993, elem: Some(TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 49, 129, 25, 3, 231] }) },
+        TestItem { ctr: 4994, elem: Some(TestElem::End { seq_no: NonZeroU32::new(999).unwrap(), calc_crc: 2388236464 }) },
+    ];
+
+    assert_eq!(contents, expected);
+
+    // Simulate a reboot
+    static LIST2: StorageList<CriticalSectionRawMutex> = StorageList::new();
+    static NODE_A2: StorageListNode<SimpleConfig> = StorageListNode::new("test/config1");
+    static NODE_B2: StorageListNode<SimpleConfig> = StorageListNode::new("test/config2");
+    static NODE_C2: StorageListNode<SimpleConfig> = StorageListNode::new("test/config3");
+
+    let stopper = Arc::new(WaitQueue::new());
+    let hdl = tokio::task::spawn_local(worker_task_tst_sto_custom(&LIST2, stopper.clone(), rpt.flash));
+
+    let node_a = NODE_A2.attach(&LIST2).await.unwrap();
+    let node_b = NODE_B2.attach(&LIST2).await.unwrap();
+    let node_c = NODE_C2.attach(&LIST2).await.unwrap();
+
+    assert_eq!(node_a.load().await.unwrap().data, 999);
+    assert_eq!(node_b.load().await.unwrap().data, 9990);
+    assert_eq!(node_c.load().await.unwrap().data, 99900);
+
+    yield_now().await;
+
+    stopper.close();
+    let rpt = hdl.await.unwrap();
+    rpt.assert_no_errs();
+
+    let contents = &rpt.flash.items;
+    // Just rebooting did not cause any change to the contents of the flash
+    assert_eq!(contents, expected);
+
+    // Simulate a reboot
+    static LIST3: StorageList<CriticalSectionRawMutex> = StorageList::new();
+    static NODE_A3: StorageListNode<SimpleConfig> = StorageListNode::new("test/config1");
+    static NODE_B3: StorageListNode<SimpleConfig> = StorageListNode::new("test/config2");
+    static NODE_C3: StorageListNode<SimpleConfig> = StorageListNode::new("test/config3");
+
+    let stopper = Arc::new(WaitQueue::new());
+    let hdl = tokio::task::spawn_local(worker_task_tst_sto_custom(&LIST3, stopper.clone(), rpt.flash));
+
+    let node_a = NODE_A3.attach(&LIST3).await.unwrap();
+    let node_b = NODE_B3.attach(&LIST3).await.unwrap();
+    let node_c = NODE_C3.attach(&LIST3).await.unwrap();
+
+    assert_eq!(node_a.load().await.unwrap().data, 999);
+    assert_eq!(node_b.load().await.unwrap().data, 9990);
+    assert_eq!(node_c.load().await.unwrap().data, 99900);
+
+    yield_now().await;
+
+    // Do one more write
+    node_a.write(&SimpleConfig { data: 1000 }).await.unwrap();
+    node_b.write(&SimpleConfig { data: 10000 }).await.unwrap();
+    node_c.write(&SimpleConfig { data: 100000 }).await.unwrap();
+
+    yield_now().await;
+
+    stopper.close();
+    let rpt = hdl.await.unwrap();
+    rpt.assert_no_errs();
+
+    #[rustfmt::skip]
+    let expected2 = &[
+        // Oldest item, seq_no 998
+        TestItem { ctr: 4985, elem: Some(TestElem::Start { seq_no: NonZeroU32::new(998).unwrap() }) },
+            TestItem { ctr: 4986, elem: Some(TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 51, 129, 26, 0, 1, 133, 216] }) },
+            TestItem { ctr: 4987, elem: Some(TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 50, 129, 25, 38, 252] }) },
+            TestItem { ctr: 4988, elem: Some(TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 49, 129, 25, 3, 230] }) },
+        TestItem { ctr: 4989, elem: Some(TestElem::End { seq_no: NonZeroU32::new(998).unwrap(), calc_crc: 1413754379 }) },
+        // Middle item, seq_no 999
+        TestItem { ctr: 4990, elem: Some(TestElem::Start { seq_no: NonZeroU32::new(999).unwrap() }) },
+            TestItem { ctr: 4991, elem: Some(TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 51, 129, 26, 0, 1, 134, 60] }) },
+            TestItem { ctr: 4992, elem: Some(TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 50, 129, 25, 39, 6] }) },
+            TestItem { ctr: 4993, elem: Some(TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 49, 129, 25, 3, 231] }) },
+        TestItem { ctr: 4994, elem: Some(TestElem::End { seq_no: NonZeroU32::new(999).unwrap(), calc_crc: 2388236464 }) },
+        // Newest item, seq_no 1000
+        TestItem { ctr: 4995, elem: Some(TestElem::Start { seq_no: NonZeroU32::new(1000).unwrap() }) },
+            TestItem { ctr: 4996, elem: Some(TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 51, 129, 26, 0, 1, 134, 160] }) },
+            TestItem { ctr: 4997, elem: Some(TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 50, 129, 25, 39, 16] }) },
+            TestItem { ctr: 4998, elem: Some(TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 49, 129, 25, 3, 232] }) },
+        TestItem { ctr: 4999, elem: Some(TestElem::End { seq_no: NonZeroU32::new(1000).unwrap(), calc_crc: 2217662377 }) },
+    ];
+
+    let contents = &rpt.flash.items;
+    // New write resumed correctly
+    assert_eq!(contents, expected2);
+}

--- a/tests/many_good_writes.rs
+++ b/tests/many_good_writes.rs
@@ -36,9 +36,9 @@ async fn many_good_writes_inner() {
     let node_b = NODE_B.attach(&LIST).await.unwrap();
     let node_c = NODE_C.attach(&LIST).await.unwrap();
 
-    assert_eq!(node_a.load().await.unwrap().data, 0);
-    assert_eq!(node_b.load().await.unwrap().data, 0);
-    assert_eq!(node_c.load().await.unwrap().data, 0);
+    assert_eq!(node_a.load().await.unwrap(), SimpleConfig::default());
+    assert_eq!(node_b.load().await.unwrap(), SimpleConfig::default());
+    assert_eq!(node_c.load().await.unwrap(), SimpleConfig::default());
 
     // yield to ensure initial gc has a chance to run
     yield_now().await;


### PR DESCRIPTION
Closes #29 
Closes #31 

Implements the process described in https://github.com/tweedegolf/cfg-noodle/issues/29#issuecomment-2970505755.

~Seems to basically work (existing tests pass), but definitely needs more testing before it is ready.~

This also changes the interface of the trait - we can now yield invalid nodes during iteration, which allows us to access "bad" nodes so we can `invalidate` them. I should look and see if having the `step` and `skip_to_seq` macros still make sense, their main existence was to paper over "bad" element nodes.

~Will do more testing on Monday.~