### PR TITLE
Some tweaks from hardware testing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,12 +26,12 @@ arbitrary = ["dep:arbitrary"]
 
 [dependencies]
 embedded-storage-async = "0.4.1"
-minicbor = { version = "1.0.0", features = ["derive"] }
+minicbor = { version = "1.0.0", default-features = false, features = ["derive"] }
 sequential-storage = "4.0.1"
 
-cordyceps = "0.3.4"
+cordyceps = { version = "0.3.4", default-features = false }
 critical-section = "1.2.0"
-maitake-sync = "0.2.1"
+maitake-sync = { version = "0.2.1", default-features = false }
 mutex = { version = "1.0.0", features = ["impl-critical-section"] }
 
 pin-project = "1.1.10"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,7 @@ mod consts {
 /// Serialized Data Element
 ///
 /// Includes header, key, and value
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, PartialEq)]
 pub struct SerData<'a> {
     hdr_key_val: &'a [u8],
@@ -120,6 +121,7 @@ impl<'a> SerData<'a> {
 }
 
 /// A single element stored in flash
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, PartialEq)]
 pub enum Elem<'a> {
     /// Start element

--- a/src/storage_node.rs
+++ b/src/storage_node.rs
@@ -323,6 +323,16 @@ where
     T: Clone + Send + 'static,
     R: ScopedRawMutex + 'static,
 {
+    /// Obtain the key of a node
+    pub async fn key(&self) -> &str {
+        // todo: this probably doesn't need to be async
+        //
+        // update to be non-async when we work on https://github.com/tweedegolf/cfg-noodle/issues/34
+        let _inner = self.list.inner.lock().await;
+        let nodeptr: *mut Node<T> = self.inner.inner.get();
+        let noderef = unsafe { &*nodeptr };
+        noderef.header.key
+    }
     /// This is a `load` function that copies out the data
     ///
     /// Note that we *copy out*, instead of returning a ref, because we MUST hold


### PR DESCRIPTION
Some dependencies were pulling in std/alloc by default. Also add some more defmt derives and a helper function for getting the key out of a node (useful in testing)