### PR TITLE
Bump sequential storage to 4.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,9 +102,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "backtrace"
@@ -547,9 +547,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.173"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8cfeafaffdbc32176b64fb251369d52ea9f0a8fbc6f8759edffef7b525d64bb"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "litrs"
@@ -881,9 +881,9 @@ checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "sequential-storage"
-version = "4.0.2"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5249081d175080e20472df92331fed2071187a9984d26c6c6f426d22f3e608eb"
+checksum = "516ed74ad8268ec0d78c574af8fc7e09a9c3a0df63c7692c588a10d7097dea3b"
 dependencies = [
  "approx",
  "arrayvec",
@@ -1088,9 +1088,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1ffbcf9c6f6b99d386e7444eb608ba646ae452a36b39737deb9663b610f662"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ arbitrary = ["dep:arbitrary"]
 [dependencies]
 embedded-storage-async = "0.4.1"
 minicbor = { version = "1.0.0", default-features = false, features = ["derive"] }
-sequential-storage = "4.0.1"
+sequential-storage = "4.0.2"
 
 cordyceps = { version = "0.3.4", default-features = false }
 critical-section = "1.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ arbitrary = ["dep:arbitrary"]
 [dependencies]
 embedded-storage-async = "0.4.1"
 minicbor = { version = "1.0.0", default-features = false, features = ["derive"] }
-sequential-storage = "4.0.2"
+sequential-storage = "4.0.3"
 
 cordyceps = { version = "0.3.4", default-features = false }
 critical-section = "1.2.0"


### PR DESCRIPTION
My IDE was complaining that sequential-storage has a newer version available and v4.0.2 includes some changes that we surely want to have.