### PR TITLE
Various atomic fixes

### DIFF
--- a/src/storage_list.rs
+++ b/src/storage_list.rs
@@ -333,7 +333,8 @@ impl<R: ScopedRawMutex> StorageList<R> {
                 State::NonResident => false,
                 // We DO update default unwritten nodes
                 State::DefaultUnwritten => true,
-                // technically we could update, but we will anyway
+                // technically we could skip updating (we're already in this state),
+                // but we will update anyway
                 State::ValidNoWriteNeeded => true,
                 // We DO update needs write nodes
                 State::NeedsWrite => true,


### PR DESCRIPTION
Fixed a couple of bugs, and made some changes that I think are correct. Big ones:

* We weren't properly checking if nodes were in the right state before serializing
* We weren't properly checking if nodes were in the right state after serializing when marking them as written
* Fixed a theoretical race condition when attaching, probably only possible to observe in multithreaded/interrupt/multicore systems (see `wait_for_value` call)
* Ensure that we NEVER create an `&mut Node<T>`, since we have shared `&NodeHeader`s that could alias with these. Instead we just take the NodeHeader when we can, and make a separate `&mut MaybeUninit<T>` when necessary/valid

I also moved some orderings from Relaxed to Acquire/Release when they involve the StorageList doing things where the Node themselves may be atomically touching the state. This is possibly overly cautious, but since we are mixing non-locked access to state, it makes me a little nervous not to.