### PR TITLE
Doing write requires exclusive access to the handle

### DIFF
--- a/src/storage_list.rs
+++ b/src/storage_list.rs
@@ -1217,7 +1217,7 @@ mod test {
                     tokio::task::spawn_local(worker_task_seq_sto(&GLOBAL_LIST, flash));
 
                 // Obtain a handle for the first config
-                let config_handle = match POSITRON_CONFIG1.attach(&GLOBAL_LIST).await {
+                let mut config_handle = match POSITRON_CONFIG1.attach(&GLOBAL_LIST).await {
                     Ok(ch) => ch,
                     Err(_) => panic!("Could not attach config 1 to list"),
                 };
@@ -1228,8 +1228,7 @@ mod test {
                 }
 
                 // Load data for the first handle
-                let data: PositronConfig = config_handle
-                    .load();
+                let data: PositronConfig = config_handle.load();
                 info!("T3 Got {data:?}");
 
                 // Write a new config to first handle
@@ -1247,11 +1246,7 @@ mod test {
                 sleep(Duration::from_millis(100)).await;
 
                 // Assert that the loaded value equals the written value
-                assert_eq!(
-                    config_handle
-                        .load(),
-                    new_config
-                );
+                assert_eq!(config_handle.load(), new_config);
 
                 // Wait for the worker task to finish
                 let _ = tokio::time::timeout(Duration::from_millis(100), worker_task).await;
@@ -1277,7 +1272,7 @@ mod test {
                     tokio::task::spawn_local(worker_task_tst_sto(&GLOBAL_LIST, stopper.clone()));
 
                 // Obtain a handle for the first config
-                let config_handle = match POSITRON_CONFIG1.attach(&GLOBAL_LIST).await {
+                let mut config_handle = match POSITRON_CONFIG1.attach(&GLOBAL_LIST).await {
                     Ok(ch) => ch,
                     Err(_) => panic!("Could not attach config 1 to list"),
                 };
@@ -1288,8 +1283,7 @@ mod test {
                 };
 
                 // Load data for the first handle
-                let data: PositronConfig = config_handle
-                    .load();
+                let data: PositronConfig = config_handle.load();
                 info!("T3 Got {data:?}");
 
                 // Write a new config to first handle
@@ -1307,11 +1301,7 @@ mod test {
                 sleep(Duration::from_millis(100)).await;
 
                 // Assert that the loaded value equals the written value
-                assert_eq!(
-                    config_handle
-                        .load(),
-                    new_config
-                );
+                assert_eq!(config_handle.load(), new_config);
 
                 // Wait for the worker task to finish
                 stopper.close();
@@ -1366,8 +1356,7 @@ mod test {
 
                 assert_eq!(
                     custom_config,
-                    expecting_already_present
-                        .load(),
+                    expecting_already_present.load(),
                     "Key should already be present"
                 );
 

--- a/src/storage_node.rs
+++ b/src/storage_node.rs
@@ -483,7 +483,7 @@ where
     }
 
     /// Write data to the buffer, and mark the buffer as "needs to be flushed".
-    pub async fn write(&self, t: &T) -> Result<(), Error> {
+    pub async fn write(&mut self, t: &T) -> Result<(), Error> {
         let _inner = self.list.inner.lock().await;
 
         let nodeptr: *mut Node<T> = self.inner.inner.get();

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -91,7 +91,7 @@ async fn test_read_clean_state() {
             let worker =
                 tokio::task::spawn_local(test_utils::worker_task_tst_sto(&LIST, stopper.clone()));
 
-            let handle = NODE.attach(&LIST).await.unwrap();
+            let mut handle = NODE.attach(&LIST).await.unwrap();
 
             let test_config = TestConfig {
                 value: 42,
@@ -161,7 +161,7 @@ async fn test_read_clean_state_new_config() {
             let worker =
                 tokio::task::spawn_local(test_utils::worker_task_tst_sto(&LIST, stopper.clone()));
 
-            let handle = NODE.attach(&LIST).await.unwrap();
+            let mut handle = NODE.attach(&LIST).await.unwrap();
 
             let test_config = TestConfig {
                 value: 42,
@@ -246,8 +246,8 @@ async fn test_read_interrupted_write() {
             let worker =
                 tokio::task::spawn_local(test_utils::worker_task_tst_sto(&LIST, stopper.clone()));
 
-            let handle1 = NODE1.attach(&LIST).await.unwrap();
-            let handle2 = NODE2.attach(&LIST).await.unwrap();
+            let mut handle1 = NODE1.attach(&LIST).await.unwrap();
+            let mut handle2 = NODE2.attach(&LIST).await.unwrap();
             let test_config1 = TestConfig {
                 value: 1,
                 truth: false,

--- a/tests/many_good_writes.rs
+++ b/tests/many_good_writes.rs
@@ -34,9 +34,9 @@ async fn many_good_writes_inner() {
     let stopper = Arc::new(WaitQueue::new());
     let hdl = tokio::task::spawn_local(worker_task_tst_sto(&LIST, stopper.clone()));
 
-    let node_a = NODE_A.attach(&LIST).await.unwrap();
-    let node_b = NODE_B.attach(&LIST).await.unwrap();
-    let node_c = NODE_C.attach(&LIST).await.unwrap();
+    let mut node_a = NODE_A.attach(&LIST).await.unwrap();
+    let mut node_b = NODE_B.attach(&LIST).await.unwrap();
+    let mut node_c = NODE_C.attach(&LIST).await.unwrap();
 
     assert_eq!(node_a.load(), SimpleConfig::default());
     assert_eq!(node_b.load(), SimpleConfig::default());
@@ -131,9 +131,9 @@ async fn many_good_writes_inner() {
         rpt.flash,
     ));
 
-    let node_a = NODE_A3.attach(&LIST3).await.unwrap();
-    let node_b = NODE_B3.attach(&LIST3).await.unwrap();
-    let node_c = NODE_C3.attach(&LIST3).await.unwrap();
+    let mut node_a = NODE_A3.attach(&LIST3).await.unwrap();
+    let mut node_b = NODE_B3.attach(&LIST3).await.unwrap();
+    let mut node_c = NODE_C3.attach(&LIST3).await.unwrap();
 
     assert_eq!(node_a.load().data, 999);
     assert_eq!(node_b.load().data, 9990);


### PR DESCRIPTION
Caught by Tamme, otherwise it could be possible to concurrently do a write and load, which could possibly observe read tearing.