### PR TITLE
Rescope unsafe, revise safety rules

### DIFF
--- a/crates/cfg-noodle/src/safety_guide.rs
+++ b/crates/cfg-noodle/src/safety_guide.rs
@@ -56,34 +56,59 @@
 //!     * NODE ONLY TRANSITION
 //!     * during `detach()` call
 //!
-//! ### `StorageList` Rules
+//! ### Rules List
 //!
-//! 1. When attaching (or detaching) nodes, we MUST be holding the mutex.
-//! 2. When changing the state of a node, we MUST be holding the mutex (for the
-//!    full operation, e.g. also when writing to T in transition #2).
-//! 3. The ONLY time the list may take a mut ref to the `t`, is while IN the
-//!    Initial state, AND while holding the mutex
+//! 1. `StorageListNode`, `Node<T>`, and `NodeHeader`s (collectively, "the Node") are ALWAYS
+//!    shared. Nodes have four fields that utilize inner-mutability with certain rules:
+//!     1. The "List Pointer": `StorageListNode->taken_for_list`
+//!         * The "List Pointer" is used to track which list (if any) the Node is attached to
+//!         * The "List Pointer" is used to track whether a `StorageListNodeHandle` is live or not
+//!     2. The "Data Item": `Node->t`
+//!     3. The "State": `NodeHeader->state`
+//!     4. The "Linked List": `NodeHeader->links`
+//! 2. The Node "List Pointer" may be modified IFF:
+//!     1. When Attaching a Node to a List, the list's mutex is locked AND:
+//!         1. The "List Pointer" is currently null, OR
+//!         2. The "List Pointer" points to the list we are attaching to, and we are re-attaching
+//!     2. When dropping a `StorageListNodeHandle`:
+//!         1. The lowest bit of the "List Pointer" is changed from `0b1` to `0b0`
+//!     3. When detaching a Node from a List:
+//!         1. No `StorageListNodeHandle` is live for this Node, AND
+//!         2. The mutex for the List that the List Pointer points to is locked,
+//!         3. The "List Pointer" is set to null when the detach is complete.
+//! 3. The Node "Data Item" may be modified IFF:
+//!     1. The Node is attached to a List, AND:
+//!         1. The mutex for the List is locked
+//!         2. . Any of the following are true:
+//!             1. If updated by `process_reads()`: The Node is in the "Initial" state, OR
+//!             2. If updated by `attach()`: The Node is in the "NonResident" state, OR
+//!             3. If updated by `Handle::write()` (no additional requirements).
+//!     2. The Node is NOT attached to a List, and the Data Item is being reset during `detach()`.
+//! 4. The Node "State" may be be modified IFF:
+//!     1. If updated by the List, the List's mutex is locked, AND:
+//!         1. The List is moving the state from Initial to NonResident, OR
+//!         2. The List is moving the state from Initial to ValidNoWriteNeeded, OR
+//!         3. The List is moving the state from NeedsWrite to ValidNoWriteNeeded
+//!     2. If updated by the Node:
+//!         1. The list's mutex is locked AND the Node is moving the state from NonResident -> NeedsWrite
+//!         2. The list's mutex is locked AND the Node is moving the state from ValidNoWriteNeeded -> NeedsWrite
+//!         3. The node is detached from any lists AND the Node is moving from any state to Initial.
+//! 5. The Node "Linked List" may be modified IFF:
+//!     1. When attaching to a list:
+//!         1. The Node must not already be attached to a List, AND
+//!         2. The mutex for the list the node is being attached to is locked
+//!     2. When detaching from a list:
+//!         1. No `StorageListNodeHandle` is live for this Node, AND
+//!         2. The mutex for the list the node is being detached from is locked
+//! 6. A `StorageListNodeHandle` may NOT be created unless:
+//!     1. The Node is attached to a list
+//!     2. No other `StorageListNodeHandle` is live for this Node
+//!     3. The Node's "List Pointer"'s lowest bit is set to `0b1` to denote a handle is live
+//!     4. The Node is NOT in the Initial or NonResident states.
+//! 7. Shared access to the "Data Item" is allowed IFF:
+//!     1. If accessed via the StorageListNodeHandle
+//!     2. If accessed via the List:
+//!         1. The Node is NOT in the Initial or NonResident state
+//!         2. The mutex for the List is held
+//! 8. The List may traverse the linked list of nodes IFF the mutex for the list is held
 //!
-//! ### `StorageListNode`/`StorageListNodeHandle` Rules
-//!
-//! 1. The Node header is ALWAYS shared, EXCEPT at the time of attach or detach,
-//!    at which point we will hold a mut ref to (un)link to the list, this
-//!    requires we hold the mutex.
-//! 2. A Node must be attached to zero or one lists at one time:
-//!     * We must guarantee a node is prevented from being added to a second
-//!       list, if it already exists in one.
-//!     * Users MUST detach the node from the list it is in before attaching it
-//!       to a new list.
-//! 3. A Node must have zero or one handles live at one time:
-//!     * We must guarantee a handle is prevented from being created if the node
-//!       already has a handle live
-//!     * The previous handle MUST be dropped before we create a new handle
-//! 4. `attach()` MUST NOT complete/we MUST NOT create a StorageListNodeHandle
-//!    UNTIL we are no longer in the Initial state.
-//! 5. DURING `StorageListNode::attach()`, we may ONLY take a mut ref to `t` IF
-//!    we are in the NonResident state, AND we hold the mutex.
-//! 6. During `StorageListNodeHandle::write()`, we MUST hold the mutex for the whole operation.
-//! 7. During `StorageListNodeHandle::load()`, we DO NOT need the mutex,
-//!    because we've already guaranteed we are not in Initial/NonResident state,
-//!    and the list will never attempt to mutate `t`, but may also have a shared
-//!    ref to `t`.

--- a/crates/cfg-noodle/src/safety_guide.rs
+++ b/crates/cfg-noodle/src/safety_guide.rs
@@ -100,11 +100,10 @@
 //!     2. When detaching from a list:
 //!         1. No `StorageListNodeHandle` is live for this Node, AND
 //!         2. The mutex for the list the node is being detached from is locked
-//! 6. A `StorageListNodeHandle` may NOT be created unless:
+//! 6. A `StorageListNodeHandle` may only be created IFF:
 //!     1. The Node is attached to a list
 //!     2. No other `StorageListNodeHandle` is live for this Node
-//!     3. The Node's "List Pointer"'s lowest bit is set to `0b1` to denote a handle is live
-//!     4. The Node is NOT in the Initial or NonResident states.
+//!     3. The Node is NOT in the Initial or NonResident states.
 //! 7. Shared access to the "Data Item" is allowed IFF:
 //!     1. If accessed via the `StorageListNodeHandle`
 //!     2. If accessed via the List:

--- a/crates/cfg-noodle/src/safety_guide.rs
+++ b/crates/cfg-noodle/src/safety_guide.rs
@@ -67,32 +67,32 @@
 //!     3. The "State": `NodeHeader->state`
 //!     4. The "Linked List": `NodeHeader->links`
 //! 2. The Node "List Pointer" may be modified IFF:
-//!     1. When Attaching a Node to a List, the list's mutex is locked AND:
+//!     1. When attaching a Node to a List, the list's mutex is locked AND:
 //!         1. The "List Pointer" is currently null, OR
 //!         2. The "List Pointer" points to the list we are attaching to, and we are re-attaching
 //!     2. When dropping a `StorageListNodeHandle`:
 //!         1. The lowest bit of the "List Pointer" is changed from `0b1` to `0b0`
 //!     3. When detaching a Node from a List:
 //!         1. No `StorageListNodeHandle` is live for this Node, AND
-//!         2. The mutex for the List that the List Pointer points to is locked,
+//!         2. The mutex for the List that the "List Pointer" points to is locked,
 //!         3. The "List Pointer" is set to null when the detach is complete.
 //! 3. The Node "Data Item" may be modified IFF:
 //!     1. The Node is attached to a List, AND:
 //!         1. The mutex for the List is locked
-//!         2. . Any of the following are true:
+//!         2. Any of the following are true:
 //!             1. If updated by `process_reads()`: The Node is in the "Initial" state, OR
 //!             2. If updated by `attach()`: The Node is in the "NonResident" state, OR
 //!             3. If updated by `Handle::write()` (no additional requirements).
-//!     2. The Node is NOT attached to a List, and the Data Item is being reset during `detach()`.
+//!     2. The Node is NOT attached to a List, and the "Data Item" is being reset during `detach()`.
 //! 4. The Node "State" may be be modified IFF:
 //!     1. If updated by the List, the List's mutex is locked, AND:
-//!         1. The List is moving the state from Initial to NonResident, OR
-//!         2. The List is moving the state from Initial to ValidNoWriteNeeded, OR
-//!         3. The List is moving the state from NeedsWrite to ValidNoWriteNeeded
+//!         1. The List is moving the "State" from Initial to NonResident, OR
+//!         2. The List is moving the "State" from Initial to ValidNoWriteNeeded, OR
+//!         3. The List is moving the "State" from NeedsWrite to ValidNoWriteNeeded
 //!     2. If updated by the Node:
-//!         1. The list's mutex is locked AND the Node is moving the state from NonResident -> NeedsWrite
-//!         2. The list's mutex is locked AND the Node is moving the state from ValidNoWriteNeeded -> NeedsWrite
-//!         3. The node is detached from any lists AND the Node is moving from any state to Initial.
+//!         1. The list's mutex is locked AND the Node is moving the "State" from NonResident -> NeedsWrite
+//!         2. The list's mutex is locked AND the Node is moving the "State" from ValidNoWriteNeeded -> NeedsWrite
+//!         3. The node is detached from any lists AND the Node is moving from any "State" to Initial.
 //! 5. The Node "Linked List" may be modified IFF:
 //!     1. When attaching to a list:
 //!         1. The Node must not already be attached to a List, AND
@@ -106,9 +106,9 @@
 //!     3. The Node's "List Pointer"'s lowest bit is set to `0b1` to denote a handle is live
 //!     4. The Node is NOT in the Initial or NonResident states.
 //! 7. Shared access to the "Data Item" is allowed IFF:
-//!     1. If accessed via the StorageListNodeHandle
+//!     1. If accessed via the `StorageListNodeHandle`
 //!     2. If accessed via the List:
 //!         1. The Node is NOT in the Initial or NonResident state
-//!         2. The mutex for the List is held
-//! 8. The List may traverse the linked list of nodes IFF the mutex for the list is held
+//!         2. The mutex for the List is locked
+//! 8. The List may traverse the linked list of nodes IFF the mutex for the list is locked
 //!

--- a/crates/cfg-noodle/src/storage_list.rs
+++ b/crates/cfg-noodle/src/storage_list.rs
@@ -339,6 +339,7 @@ impl<R: ScopedRawMutex> StorageList<R> {
             };
             if update {
                 // Mark the store as complete
+                // Rule 4.1.3: We can move from NeedsWrite -> ValidNoWriteNeeded
                 hdrref
                     .state
                     .store(State::ValidNoWriteNeeded.into_u8(), Ordering::Release);
@@ -465,9 +466,9 @@ impl StorageListInner {
     /// * `Some(NonNull<NodeHeader>)` - A non-null pointer to the matching node header
     /// * `None` - If no node with the given key exists in the list
     pub(crate) fn find_node(&mut self, key: &str) -> Option<NonNull<NodeHeader>> {
-        // SAFETY: StorageListNode Rule 1: NodeHeader access is ALWAYS shared,
-        // StorageListInner is only usable with the mutex locked, preventing attach/detach
-        // of new nodes.
+        // SAFETY:
+        // - Rule 1: NodeHeader access is ALWAYS shared
+        // - Rule 8: StorageListInner is only usable with the mutex locked
         //
         // NOTE: although we could use `iter` for the search, we need to return a pointer
         // with full node provenance, so we use iter_raw instead.
@@ -668,9 +669,7 @@ impl StorageListInner {
             };
 
             let header_meta = {
-                // SAFETY: StorageListNode Rule 1: NodeHeader access is ALWAYS shared,
-                // StorageListInner is only usable with the mutex locked, preventing attach/detach
-                // of new nodes.
+                // SAFETY: Rule 1: NodeHeader access is ALWAYS shared
                 let node_header = unsafe { node_header.as_ref() };
                 match State::from_u8(node_header.state.load(Ordering::Acquire)) {
                     State::Initial => Some(node_header.vtable),
@@ -686,17 +685,18 @@ impl StorageListInner {
 
                 // Call the deserialization function
                 //
-                // SAFETY: StorageList Rule 3: We have the mutex locked, and we have checked the
-                // node is in the Initial state.
+                // SAFETY:
+                // - Rule 3.1: The node is part of this list
+                // - Rule 3.1.1: The mutex is locked
+                // - Rule 3.1.2.1: We checked the node is in the Initial state
                 let res = unsafe { (vtable.deserialize)(nodeptr, kvpair.body) };
 
-                // SAFETY: StorageListNode Rule 1: NodeHeader access is ALWAYS shared,
-                // StorageListInner is only usable with the mutex locked, preventing attach/detach
-                // of new nodes.
+                // SAFETY: Rule 1: NodeHeader access is ALWAYS shared
                 let hdrref = unsafe { hdrptr.as_ref() };
 
-                // SAFETY: StorageList Rule 2: We are holding the mutex, we can change
-                // the state of the node.
+                // SAFETY:
+                // - Rule 4.1: We are holding the mutex
+                // - Rule 4.1.1 or Rule 4.1.2: We are moving from Initial to ValidNoWriteNeeded/NonResident
                 if res.is_ok() {
                     // If it went okay, let the node know that it has been hydrated with data
                     //
@@ -743,6 +743,7 @@ impl StorageListInner {
         storage: &mut S,
         seq_no: NonZeroU32,
     ) -> Result<WriteReport, LoadStoreError<S::Error>> {
+        // SAFETY: Rule 8: We can traverse the list with the mutex locked
         let iter = StaticRawIter {
             iter: self.list.iter_raw(),
         };
@@ -756,9 +757,7 @@ impl StorageListInner {
         for hdrptr in iter {
             // First: is this a node that is VALID for serialization?
             let state = {
-                // SAFETY: StorageListNode Rule 1: NodeHeader access is ALWAYS shared,
-                // StorageListInner is only usable with the mutex locked, preventing attach/detach
-                // of new nodes.
+                // SAFETY: Rule 1: NodeHeader access is ALWAYS shared
                 let state_ref = unsafe { &*addr_of!((*hdrptr.ptr.as_ptr()).state) };
                 let state = state_ref.load(Ordering::Acquire);
                 State::from_u8(state)
@@ -778,9 +777,9 @@ impl StorageListInner {
             // discriminant
             let (_first, rest) = buf.split_first_mut().ok_or(Error::Serialization)?;
 
-            // SAFETY: we know the node pointer is valid (and valid to read as it is NOT
-            // in the InitialNonResident state), and we know the mutex is held
-            // (StorageListInner access requires it).
+            // SAFETY:
+            // - Rule 7.2.1: Node is not in Initial/NonResident state
+            // - Rule 7.2.2: the mutex is held
             let used = unsafe { serialize_node(hdrptr.ptr, rest)? };
 
             let used = &mut buf[..(used + 1)];
@@ -934,7 +933,8 @@ struct StaticRawIter<'a> {
 /// have exclusive access, and all nodes must be 'static. Therefore, it is
 /// sound to Send both the iterator, and the wrapped NonNulls it returns.
 ///
-/// StorageList Rule 1: Nodes cannot be attached/detached while holding the mutex
+/// - Rule 1: Nodes are always shared
+/// - Rule 5: The nodes may not be attached/detached while we hold the mutex
 unsafe impl Send for StaticRawIter<'_> {}
 
 impl Iterator for StaticRawIter<'_> {
@@ -961,7 +961,8 @@ struct SendPtr {
 /// have exclusive access, and all nodes must be 'static. Therefore, it is
 /// sound to Send the wrapped NonNull.
 ///
-/// StorageList Rule 1: Nodes cannot be attached/detached while holding the mutex
+/// - Rule 1: Nodes are always shared
+/// - Rule 5: The nodes may not be attached/detached while we hold the mutex
 unsafe impl Send for SendPtr {}
 
 struct KvPair<'a> {
@@ -1005,13 +1006,11 @@ fn extract(item: &[u8]) -> Result<KvPair<'_>, Error> {
 /// The caller must ensure that:
 ///
 /// - `headerptr` points to a valid NodeHeader
-/// - `headerptr` points to a node that is valid for reading (e.g. not Initial/NonResident)
-/// - The storage list mutex is held during the entire operation
+/// - Rule 7.2.1 :The Node is NOT in the Initial/NonResident state
+/// - Rule 7.2.2: The mutex MUST be held for the duration of this operation
 unsafe fn serialize_node(headerptr: NonNull<NodeHeader>, buf: &mut [u8]) -> Result<usize, Error> {
     let (vtable, key) = {
-        // SAFETY: StorageListNode Rule 1: NodeHeader access is ALWAYS shared,
-        // StorageListInner is only usable with the mutex locked, preventing attach/detach
-        // of new nodes.
+        // SAFETY: Rule 1: NodeHeader access is ALWAYS shared
         let node = unsafe { headerptr.as_ref() };
         (node.vtable, node.key)
     };
@@ -1034,9 +1033,9 @@ unsafe fn serialize_node(headerptr: NonNull<NodeHeader>, buf: &mut [u8]) -> Resu
 
     // Serialize payload into buffer
     //
-    // SAFETY: StorageListNode Rule 1: NodeHeader access is ALWAYS shared,
-    // StorageListInner is only usable with the mutex locked, preventing attach/detach
-    // of new nodes.
+    // SAFETY: Caller has guaranteed compliance with:
+    // - Rule 7.2.1 :The Node is NOT in the Initial/NonResident state
+    // - Rule 7.2.2: The mutex MUST be held for the duration of this operation
     let res = unsafe { (vtable.serialize)(nodeptr, remain) };
 
     match res {
@@ -1065,10 +1064,6 @@ unsafe fn serialize_node(headerptr: NonNull<NodeHeader>, buf: &mut [u8]) -> Resu
 /// * `Err(LoadError::WriteVerificationFailed)` - If any node doesn't match its flash entry
 /// * `Err(LoadError::FlashRead)` - If reading from flash fails
 ///
-/// # Safety
-///
-/// The caller must hold the storage list mutex (enforced by the `MutexGuard` parameter)
-/// to ensure exclusive access during verification.
 async fn verify_list_in_flash<S: NdlDataStorage>(
     storage: &mut S,
     rpt: WriteReport,

--- a/crates/cfg-noodle/src/storage_list.rs
+++ b/crates/cfg-noodle/src/storage_list.rs
@@ -339,7 +339,7 @@ impl<R: ScopedRawMutex> StorageList<R> {
             };
             if update {
                 // Mark the store as complete
-                // Rule 4.1.3: We can move from NeedsWrite -> ValidNoWriteNeeded
+                // Rule 4.1.3: We can move from NeedsWrite -> ValidNoWriteNeeded because we hold the lock
                 hdrref
                     .state
                     .store(State::ValidNoWriteNeeded.into_u8(), Ordering::Release);

--- a/crates/cfg-noodle/src/storage_node.rs
+++ b/crates/cfg-noodle/src/storage_node.rs
@@ -483,7 +483,7 @@ where
 
         // SAFETY:
         // - Rule 6.1: The node is attached to a list
-        // - Rule 6.2: No other nodes exist
+        // - Rule 6.2: No other handles exist
         // - Rule 6.3: We marked a handle as live
         // - Rule 6.4: We have passed the Initial/NonResident state
         Ok(StorageListNodeHandle {
@@ -661,7 +661,7 @@ where
         }
         // yes!
         //
-        // SAFETY: Rule 7.1: We can always obtained shared access to t
+        // SAFETY: Rule 7.1: We can always obtain shared access to t
         unsafe {
             let tptr: *mut MaybeUninit<T> = self.inner.inner.t.get();
             (*tptr).assume_init_ref().clone()
@@ -796,7 +796,7 @@ unsafe impl Linked<list::Links<NodeHeader>> for NodeHeader {
 
         // SAFETY: caller has to ensure that it the pointer points to a
         // valid instance of Self. The returned links may only be used for
-        // attaching/detaching if the mutex is held.
+        // attaching/detaching if the mutex is held (Rules 5.1.2 and 5.2.2).
         unsafe { NonNull::new_unchecked(linksptr) }
     }
 }

--- a/crates/cfg-noodle/src/storage_node.rs
+++ b/crates/cfg-noodle/src/storage_node.rs
@@ -678,8 +678,8 @@ where
         // to modify it.
         let _inner = self.list().inner.lock().await;
         let key: &'static str = self.key();
-        // We DON'T hold a lock to the list, so use Relaxed for load
-        let state = State::from_u8(self.inner.inner.header.state.load(Ordering::Relaxed));
+        // We DON'T hold a lock to the list, so use Acquire for load
+        let state = State::from_u8(self.inner.inner.header.state.load(Ordering::Acquire));
 
         match state {
             // `Initial` and `NonResident` can not occur for the same reason as

--- a/crates/cfg-noodle/src/storage_node.rs
+++ b/crates/cfg-noodle/src/storage_node.rs
@@ -12,7 +12,7 @@ use core::{
     fmt::Debug,
     marker::{PhantomData, PhantomPinned},
     mem::MaybeUninit,
-    ptr::{self, NonNull, dangling_mut, null_mut},
+    ptr::{self, NonNull, null_mut},
     sync::atomic::{AtomicPtr, AtomicU8, Ordering},
 };
 use minicbor::{

--- a/crates/cfg-noodle/src/storage_node.rs
+++ b/crates/cfg-noodle/src/storage_node.rs
@@ -432,7 +432,7 @@ where
         // now (would require interrupts/threads/multicore), and handles cases
         // where we get a spurious wake BEFORE we've actually been loaded.
         //
-        // SAFETY: Rule 6.4: waiting to pass through the Initial state
+        // SAFETY: Rule 6.3: waiting to pass through the Initial state
         let state = list
             .reading_done
             .wait_for_value(|| {
@@ -484,8 +484,7 @@ where
         // SAFETY:
         // - Rule 6.1: The node is attached to a list
         // - Rule 6.2: No other handles exist
-        // - Rule 6.3: We marked a handle as live
-        // - Rule 6.4: We have passed the Initial/NonResident state
+        // - Rule 6.3: We have passed the Initial/NonResident state
         Ok(StorageListNodeHandle {
             list_ty: PhantomData,
             inner: self,

--- a/crates/cfg-noodle/src/storage_node.rs
+++ b/crates/cfg-noodle/src/storage_node.rs
@@ -466,10 +466,10 @@ where
                 // - Rule 3.1.2.2: The node is in the NonResident state
                 let body: &mut MaybeUninit<T> = unsafe { &mut *body };
                 *body = MaybeUninit::new(f());
-                // We do hold the lock, use Relaxed ordering.
+                // We do NOT hold the lock, use Relaxed ordering.
                 hdrref
                     .state
-                    .store(State::NeedsWrite.into_u8(), Ordering::Relaxed);
+                    .store(State::NeedsWrite.into_u8(), Ordering::Release);
             }
             // This state is set by this function if the node is non resident
             State::NeedsWrite if !already_attached => {


### PR DESCRIPTION
This change "pushes down" the inner mutability to specific fields, and rewrites the safety rules to specifically address each of the rules around those fields.