### PR TITLE
Re-export more dependencies of crate

### DIFF
--- a/crates/cfg-noodle/Cargo.lock
+++ b/crates/cfg-noodle/Cargo.lock
@@ -363,6 +363,7 @@ checksum = "f820157f198ada183ad62e0a66f554c610cdcd1a9f27d4b316358103ced7a1f8"
 dependencies = [
  "cfg-if",
  "critical-section",
+ "defmt 0.3.100",
  "document-features",
  "embassy-time-driver",
  "embassy-time-queue-utils",
@@ -1062,9 +1063,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/cfg-noodle/Cargo.toml
+++ b/crates/cfg-noodle/Cargo.toml
@@ -43,6 +43,7 @@ defmt = [
     "dep:defmt",
     "embassy-futures/defmt",
     "embassy-sync/defmt",
+    "embassy-time/defmt",
     "sequential-storage/defmt-03",
 ]
 

--- a/crates/cfg-noodle/src/lib.rs
+++ b/crates/cfg-noodle/src/lib.rs
@@ -10,7 +10,11 @@ pub mod flash;
 pub mod safety_guide;
 pub mod worker_task;
 
+// re-export some dependencies
+pub use minicbor;
+pub use mutex;
 pub use mutex_traits;
+pub use sequential_storage;
 
 #[cfg(any(test, feature = "std"))]
 #[doc(hidden)]

--- a/demos/nrf52840/Cargo.lock
+++ b/demos/nrf52840/Cargo.lock
@@ -743,12 +743,9 @@ dependencies = [
  "embassy-nrf",
  "embassy-sync 0.6.2",
  "embassy-time",
- "minicbor",
- "mutex",
  "mx25r",
  "panic-probe",
  "portable-atomic",
- "sequential-storage",
  "static_cell",
 ]
 

--- a/demos/nrf52840/Cargo.toml
+++ b/demos/nrf52840/Cargo.toml
@@ -12,8 +12,6 @@ embassy-nrf             = { version = "0.3.1", features = ["defmt", "nrf52840", 
 # embassy-nrf 0.3.1 uses embassy-sync 0.6.2, so we must use that, too, for now.
 embassy-sync            = { version = "0.6.2", features = ["defmt"] }
 embassy-time            = { version = "0.4.0", features = ["defmt", "defmt-timestamp-uptime"] }
-minicbor                = { version = "1.0.0", features = ["derive"], default-features = false }
-mutex                   = { version = "1.0.0", features = ["impl-critical-section"], default-features = false }
 panic-probe             = { version = "1.0.0",   features = ["print-defmt"] }
 portable-atomic         = { version = "1.11.1", features = ["critical-section"] }
 
@@ -24,7 +22,6 @@ defmt                   = "1.0.1"
 defmt-rtt               = "1.0.0"
 embassy-embedded-hal    = "0.3.0"
 embassy-futures         = "0.1.1"
-sequential-storage      = "4.0.3"
 static_cell             = "2.1"
 
 [profile.release]

--- a/demos/nrf52840/src/noodle.rs
+++ b/demos/nrf52840/src/noodle.rs
@@ -4,16 +4,19 @@
 //! of LEDs, with speed changable via user button press. The blinking speed of the
 //! LEDs is persistently stored in the cfg-noodle storage in external flash.
 
-use cfg_noodle::{flash::Flash, StorageList, StorageListNode};
+use cfg_noodle::{
+    flash::Flash,
+    minicbor::{self, CborLen, Decode, Encode},
+    mutex::raw_impls::cs::CriticalSectionRawMutex,
+    sequential_storage::cache::PagePointerCache,
+    StorageList, StorageListNode,
+};
 use defmt::{error, info};
 use embassy_executor::task;
 use embassy_futures::select::{select, Either};
 use embassy_nrf::gpio::{Input, Output};
 use embassy_time::{Duration, Instant, Timer, WithTimeout};
-use minicbor::{CborLen, Decode, Encode};
-use mutex::raw_impls::cs::CriticalSectionRawMutex;
 use mx25r::address::SECTOR_SIZE;
-use sequential_storage::cache::PagePointerCache;
 use static_cell::ConstStaticCell;
 
 use crate::DkMX25R;


### PR DESCRIPTION
Re-export from cfg-noodle crate:
- minicbor
- mutex
- sequential-storage

The other dependencies the crate and demo share didn't seem reasonable to re-export from cfg-noodle (but I am happy to discuss re-exporting more deps).