### PR TITLE
Add I/O report counters for `process_*` functions

### DIFF
--- a/crates/cfg-noodle/src/flash.rs
+++ b/crates/cfg-noodle/src/flash.rs
@@ -128,7 +128,7 @@ where
     }
 
     const MAX_ELEM_SIZE: usize = const {
-        // We start from the max erase size
+        // We start from the (min) erase size for the flash
         let baseline = T::ERASE_SIZE;
 
         // Each sector has some metadata: two words

--- a/crates/cfg-noodle/src/flash.rs
+++ b/crates/cfg-noodle/src/flash.rs
@@ -95,7 +95,7 @@ where
         })
     }
 
-    async fn push(&mut self, data: &Elem<'_>) -> Result<(), Self::Error> {
+    async fn push(&mut self, data: &Elem<'_>) -> Result<usize, Self::Error> {
         // scratch buffer used if this is start/end
         let mut buf = [0u8; 9];
         let used = match data {
@@ -122,7 +122,9 @@ where
             used,
             false,
         )
-        .await
+        .await?;
+
+        Ok(used.len())
     }
 
     const MAX_ELEM_SIZE: usize = T::ERASE_SIZE
@@ -188,6 +190,11 @@ impl<T: MultiwriteNorFlash, C: CacheImpl> NdlElemIterNode for FlashNode<'_, '_, 
     async fn invalidate(self) -> Result<(), Self::Error> {
         self.qit.pop().await?;
         Ok(())
+    }
+
+    fn len(&self) -> usize {
+        // TODO: Also add in s-s's item overhead!
+        self.qit.deref().len()
     }
 }
 

--- a/crates/cfg-noodle/src/lib.rs
+++ b/crates/cfg-noodle/src/lib.rs
@@ -209,11 +209,13 @@ pub trait NdlDataStorage {
 
     /// Insert an element at the FRONT of the list.
     ///
+    /// On success, returns the size (in bytes) of the pushed element in storage.
+    ///
     /// This method MUST be cancellation safe, however if cancelled, it is not
     /// specified whether the item has been successfully written or not.
     /// Cancellation MUST NOT lead to data loss, other than the element currently
     /// being written.
-    async fn push(&mut self, data: &Elem<'_>) -> Result<(), Self::Error>;
+    async fn push(&mut self, data: &Elem<'_>) -> Result<usize, Self::Error>;
 
     /// Return the maximum size of an `Elem` that may be stored in the list in bytes.
     ///
@@ -270,6 +272,7 @@ pub trait NdlElemIter {
 }
 
 /// A single element yielded from a NdlElemIter implementation
+#[allow(clippy::len_without_is_empty)]
 pub trait NdlElemIterNode {
     /// Error encountered while invalidating an element
     type Error;
@@ -280,6 +283,11 @@ pub trait NdlElemIterNode {
     /// This means that the storage did not consider this item invalid, however we
     /// are unable to decode it as a valid [`Elem`].
     fn data(&self) -> Option<Elem<'_>>;
+
+    /// The length (in bytes) of the element in storage, including any overhead
+    ///
+    /// This should return the length even if [`Self::data()`] returns `None`.
+    fn len(&self) -> usize;
 
     /// Invalidate the element.
     ///
@@ -294,66 +302,6 @@ pub trait NdlElemIterNode {
     /// avoided in the normal case. If this method is cancelled, the element may or
     /// may not be invalidated, however other currently-valid data MUST NOT be lost.
     async fn invalidate(self) -> Result<(), Self::Error>;
-}
-
-/// Result used by [`step`] and [`skip_to_seq`] macros
-pub type StepResult<T, E> = Result<T, StepErr<E>>;
-
-/// An error occurred while calling [`step`] or [`skip_to_seq`] macros
-#[derive(Debug, PartialEq)]
-pub enum StepErr<E> {
-    /// End of list reached
-    EndOfList,
-    /// A flash error occurred
-    FlashError(E),
-}
-
-/// Advance the iterator one step
-#[macro_export]
-macro_rules! step {
-    ($iter:ident, $buf:ident) => {
-        loop {
-            let res = $iter.next($buf).await;
-            match res {
-                // Got an item (good or bad)
-                Ok(Some(item)) => break StepResult::Ok(item),
-                // end of list
-                Ok(None) => break Err($crate::StepErr::EndOfList),
-                // flash error
-                Err(e) => break Err($crate::StepErr::FlashError(e)),
-            }
-        }
-    };
-}
-
-/// Fast-forwards the iterator to the Elem::Start item with the given seq_no.
-/// Returns an error if not found. If Err is returned, the iterator
-/// is exhausted. If Ok is returned, `Elem::Start { seq_no }` has been consumed.
-///
-/// On success, it returns the number of items consumed, including the Start item
-#[macro_export]
-macro_rules! skip_to_seq {
-    ($iter:ident, $buf:ident, $seq:ident) => {
-        {
-            let mut ctr = 0;
-            loop {
-                let res = $iter.next($buf).await;
-                ctr += 1;
-                let item = match res {
-                    // Got an item
-                    Ok(Some(item)) => item,
-                    // end of list
-                    Ok(None) => break Err($crate::StepErr::EndOfList),
-                    // flash error
-                    Err(e) => break Err($crate::StepErr::FlashError(e)),
-                };
-                if !matches!(item.data(), Some(Elem::Start { seq_no }) if seq_no == $seq) {
-                    continue;
-                }
-                break StepResult::Ok(((), ctr));
-            }
-        }
-    };
 }
 
 use crc::{CRC_32_CKSUM, Crc, Digest, NoTable};

--- a/crates/cfg-noodle/src/storage_list.rs
+++ b/crates/cfg-noodle/src/storage_list.rs
@@ -595,7 +595,7 @@ impl StorageListInner {
             ctr += 1;
 
             // Increment "data seen" counter
-            *bytes_read = *bytes_read + item.len();
+            *bytes_read += item.len();
 
             // What kind of data is this?
             match item.data() {
@@ -685,7 +685,7 @@ impl StorageListInner {
         for _ in 0..*latest.range.start() {
             match queue_iter.next(buf).await {
                 Ok(Some(item)) => {
-                    *total_bytes_read = *total_bytes_read + item.len();
+                    *total_bytes_read += item.len();
                 }
                 Ok(None) => return Err(LoadStoreError::AppError(Error::InconsistentFlash)),
                 Err(e) => return Err(LoadStoreError::FlashRead(e)),
@@ -697,7 +697,7 @@ impl StorageListInner {
             return Err(LoadStoreError::AppError(Error::InconsistentFlash));
         };
         // update the counter
-        *total_bytes_read = *total_bytes_read + item.len();
+        *total_bytes_read += item.len();
         // ...and it needs to be a Start record...
         let Some(Elem::Start { seq_no }) = item.data() else {
             return Err(LoadStoreError::AppError(Error::InconsistentFlash));
@@ -720,7 +720,7 @@ impl StorageListInner {
                 Err(e) => return Err(LoadStoreError::FlashRead(e)),
             };
             let item_len = item.len();
-            *total_bytes_read = *total_bytes_read + item_len;
+            *total_bytes_read += item_len;
 
             let data = match item.data() {
                 // Got data: great!
@@ -742,7 +742,7 @@ impl StorageListInner {
                     return Err(LoadStoreError::AppError(Error::InconsistentFlash));
                 }
             };
-            *current_bytes_read = *current_bytes_read + item_len;
+            *current_bytes_read += item_len;
 
             let Ok(kvpair) = extract(data.key_val()) else {
                 warn!("Failed to extract data on extract_all!");
@@ -1182,7 +1182,7 @@ async fn verify_list_in_flash<S: NdlDataStorage>(
         match queue_iter.next(buf).await {
             Ok(Some(item)) => {
                 total_items_seen_ctr += 1;
-                *total_bytes_read = *total_bytes_read + item.len();
+                *total_bytes_read += item.len();
                 if matches!(item.data(), Some(Elem::Start { seq_no }) if seq_no == seq) {
                     // Found it!
                     break;
@@ -1192,7 +1192,7 @@ async fn verify_list_in_flash<S: NdlDataStorage>(
             Err(e) => return Err(LoadStoreError::FlashRead(e)),
         }
     }
-    // We just saw the start counter, it's position is 1 back from the # of items seen
+    // We just saw the start counter, its position is 1 back from the # of items seen
     let start_pos = total_items_seen_ctr - 1;
 
     let mut crc = Crc32::new();
@@ -1201,7 +1201,7 @@ async fn verify_list_in_flash<S: NdlDataStorage>(
         let item = match queue_iter.next(buf).await {
             Ok(Some(i)) => {
                 debug!("visiting {:?} in verify", i.data());
-                *total_bytes_read = *total_bytes_read + i.len();
+                *total_bytes_read += i.len();
                 i
             }
             Ok(None) => {

--- a/crates/cfg-noodle/src/storage_list.rs
+++ b/crates/cfg-noodle/src/storage_list.rs
@@ -7,10 +7,9 @@
 //! [`StorageListNode`](crate::StorageListNode) and [`StorageListNodeHandle`](crate::StorageListNodeHandle)
 
 use crate::{
-    Crc32, Elem, NdlDataStorage, NdlElemIter, NdlElemIterNode, SerData, StepErr, StepResult,
+    Crc32, Elem, NdlDataStorage, NdlElemIter, NdlElemIterNode, SerData,
     error::{Error, LoadStoreError},
     logging::{debug, error, info, warn},
-    skip_to_seq, step,
     storage_node::{Node, NodeHeader, State},
 };
 use cordyceps::{List, list::IterRaw};
@@ -67,6 +66,43 @@ pub struct StorageList<R: ScopedRawMutex> {
     /// Notifies waiting nodes that the read process has completed.
     /// Woken after `process_reads` finishes loading data from flash.
     pub(crate) reading_done: WaitQueue,
+}
+
+/// Counter values from a [`StorageList::process_reads()`] operation
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
+pub struct ProcessReadCounters {
+    /// Total bytes read from storage, including any re-reads if necessary
+    pub total_bytes_read: usize,
+    /// Total data bytes used by data of the current valid write record,
+    /// used to populate the list.
+    pub current_bytes_read: usize,
+}
+
+/// Counter values from a [`StorageList::process_writes()`] operation
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
+pub struct ProcessWriteCounters {
+    /// Total bytes read from storage, including any re-reads if necessary
+    pub total_bytes_read: usize,
+    /// Total data bytes written as part of this operation
+    pub current_bytes_written: usize,
+}
+
+/// Counter values from a [`StorageList::process_garbage()`] operation
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
+pub struct ProcessGarbageCounters {
+    /// Total bytes read from storage, including any re-reads if necessary
+    pub total_bytes_read: usize,
+    /// Bytes read AFTER collection occurred. May be zero if no collection
+    /// was necessary.
+    pub post_collection_bytes_read: usize,
+    /// Total data bytes popped as part of this operation
+    pub total_bytes_popped: usize,
 }
 
 /// The functional core of a [`StorageList`]
@@ -128,6 +164,8 @@ struct WriteReport {
     crc: u32,
     /// The count of data items contained in this record
     ct: usize,
+    /// The total number of bytes written for this record
+    bytes_written: usize,
 }
 
 // --------------------------------------------------------------------------
@@ -206,7 +244,7 @@ impl<R: ScopedRawMutex> StorageList<R> {
         &'static self,
         storage: &mut S,
         buf: &mut [u8],
-    ) -> Result<(), LoadStoreError<S::Error>> {
+    ) -> Result<ProcessReadCounters, LoadStoreError<S::Error>> {
         info!("Start process_reads");
 
         if buf.len() != S::MAX_ELEM_SIZE {
@@ -224,11 +262,23 @@ impl<R: ScopedRawMutex> StorageList<R> {
         debug!("process_reads locked list");
 
         // Have we already determined the latest valid write record?
-        let res = inner.get_or_populate_latest(storage, buf).await?;
+        let mut total_bytes_read = 0usize;
+        let mut current_bytes_read = 0usize;
+        let res = inner
+            .get_or_populate_latest(storage, buf, &mut total_bytes_read)
+            .await?;
 
         // If we have something: populate all present items
         if let Some(latest) = res {
-            inner.extract_all(latest, storage, buf).await?;
+            inner
+                .extract_all(
+                    latest,
+                    storage,
+                    buf,
+                    &mut total_bytes_read,
+                    &mut current_bytes_read,
+                )
+                .await?;
         }
 
         // Now, we either have NOTHING, or we have populated all items that DO exist.
@@ -237,7 +287,10 @@ impl<R: ScopedRawMutex> StorageList<R> {
 
         debug!("Reading done. Waking all.");
         self.reading_done.wake_all();
-        Ok(())
+        Ok(ProcessReadCounters {
+            total_bytes_read,
+            current_bytes_read,
+        })
     }
 
     /// Process writes to flash.
@@ -269,7 +322,7 @@ impl<R: ScopedRawMutex> StorageList<R> {
         &'static self,
         storage: &mut S,
         buf: &mut [u8],
-    ) -> Result<(), LoadStoreError<S::Error>> {
+    ) -> Result<ProcessWriteCounters, LoadStoreError<S::Error>> {
         debug!("Start process_writes");
 
         if buf.len() != S::MAX_ELEM_SIZE {
@@ -299,7 +352,10 @@ impl<R: ScopedRawMutex> StorageList<R> {
         // If the list is unchanged, there is no need to write it to flash!
         if !needs_writing {
             debug!("List does not need writing. Returning.");
-            return Ok(());
+            return Ok(ProcessWriteCounters {
+                total_bytes_read: 0,
+                current_bytes_written: 0,
+            });
         }
 
         debug!("Attempt write_to_flash");
@@ -311,7 +367,8 @@ impl<R: ScopedRawMutex> StorageList<R> {
         // Read back all items in the list any verify the data on the flash
         // actually is what we wanted to write.
         debug!("Verifying seq {}", rpt.seq);
-        let range = verify_list_in_flash(storage, rpt, buf).await?;
+        let mut total_bytes_read = 0;
+        let range = verify_list_in_flash(storage, &rpt, buf, &mut total_bytes_read).await?;
         debug!(
             "Verified new write at pos {}..={}",
             range.start(),
@@ -346,7 +403,10 @@ impl<R: ScopedRawMutex> StorageList<R> {
             }
         }
 
-        Ok(())
+        Ok(ProcessWriteCounters {
+            total_bytes_read,
+            current_bytes_written: rpt.bytes_written,
+        })
     }
 
     /// Process garbage collection
@@ -362,13 +422,17 @@ impl<R: ScopedRawMutex> StorageList<R> {
         &'static self,
         storage: &mut S,
         buf: &mut [u8],
-    ) -> Result<(), LoadStoreError<S::Error>> {
+    ) -> Result<ProcessGarbageCounters, LoadStoreError<S::Error>> {
         // Take the mutex for a short time to copy out the current seq_state.
         let cur_seq_state = {
             let mut guard = self.inner.lock().await;
             if !guard.seq_state.needs_gc {
                 debug!("No garbage collect needed, returning Ok");
-                return Ok(());
+                return Ok(ProcessGarbageCounters {
+                    total_bytes_read: 0,
+                    post_collection_bytes_read: 0,
+                    total_bytes_popped: 0,
+                });
             }
 
             // Take the seq_state to inhibit any other reads/writes until
@@ -389,6 +453,10 @@ impl<R: ScopedRawMutex> StorageList<R> {
                 .any(|r| r.range.contains(&n))
         };
 
+        // Setup counters
+        let mut total_bytes_read = 0;
+        let mut total_bytes_popped = 0;
+
         // Create an iterator
         let mut elems = storage
             .iter_elems()
@@ -405,10 +473,13 @@ impl<R: ScopedRawMutex> StorageList<R> {
                 break;
             };
             idx += 1;
+            let used = next.len();
+            total_bytes_read += used;
 
             // If it doesn't decode: yeet
             // If it's not in a good range: yeet
             if next.data().is_none() || !last_three_contains(this_idx) {
+                total_bytes_popped += used;
                 next.invalidate()
                     .await
                     .map_err(LoadStoreError::FlashWrite)?;
@@ -424,11 +495,19 @@ impl<R: ScopedRawMutex> StorageList<R> {
         //
         // This will hold the mutex for a bit, but HOPEFULLY not for too long, as we only perform
         // reads here, never writes or erases.
+        let mut post_collection_bytes_read = 0;
         let mut inner = self.inner.lock().await;
-        inner.get_or_populate_latest(storage, buf).await?;
+        inner
+            .get_or_populate_latest(storage, buf, &mut post_collection_bytes_read)
+            .await?;
         inner.seq_state.needs_gc = false;
+        total_bytes_read += post_collection_bytes_read;
 
-        Ok(())
+        Ok(ProcessGarbageCounters {
+            total_bytes_read,
+            post_collection_bytes_read,
+            total_bytes_popped,
+        })
     }
 
     /// Returns a reference to the wait queue that signals when nodes need to be read from flash.
@@ -488,6 +567,7 @@ impl StorageListInner {
         &mut self,
         s: &mut S,
         buf: &mut [u8],
+        bytes_read: &mut usize,
     ) -> Result<Option<GoodWriteRecord>, LoadStoreError<S::Error>> {
         // If we've already scanned, we know the highest number (or that there is none)
         if self.seq_state.initial_scan_completed() {
@@ -513,6 +593,9 @@ impl StorageListInner {
             };
             let idx = ctr;
             ctr += 1;
+
+            // Increment "data seen" counter
+            *bytes_read = *bytes_read + item.len();
 
             // What kind of data is this?
             match item.data() {
@@ -585,6 +668,8 @@ impl StorageListInner {
         latest: GoodWriteRecord,
         storage: &mut S,
         buf: &mut [u8],
+        total_bytes_read: &mut usize,
+        current_bytes_read: &mut usize,
     ) -> Result<(), LoadStoreError<S::Error>> {
         let mut queue_iter = storage
             .iter_elems()
@@ -599,7 +684,9 @@ impl StorageListInner {
         // that we end up at the sequence number that we expect.
         for _ in 0..*latest.range.start() {
             match queue_iter.next(buf).await {
-                Ok(Some(_item)) => {}
+                Ok(Some(item)) => {
+                    *total_bytes_read = *total_bytes_read + item.len();
+                }
                 Ok(None) => return Err(LoadStoreError::AppError(Error::InconsistentFlash)),
                 Err(e) => return Err(LoadStoreError::FlashRead(e)),
             }
@@ -609,6 +696,8 @@ impl StorageListInner {
         let Ok(Some(item)) = queue_iter.next(buf).await else {
             return Err(LoadStoreError::AppError(Error::InconsistentFlash));
         };
+        // update the counter
+        *total_bytes_read = *total_bytes_read + item.len();
         // ...and it needs to be a Start record...
         let Some(Elem::Start { seq_no }) = item.data() else {
             return Err(LoadStoreError::AppError(Error::InconsistentFlash));
@@ -630,6 +719,8 @@ impl StorageListInner {
                 // flash error
                 Err(e) => return Err(LoadStoreError::FlashRead(e)),
             };
+            let item_len = item.len();
+            *total_bytes_read = *total_bytes_read + item_len;
 
             let data = match item.data() {
                 // Got data: great!
@@ -651,6 +742,7 @@ impl StorageListInner {
                     return Err(LoadStoreError::AppError(Error::InconsistentFlash));
                 }
             };
+            *current_bytes_read = *current_bytes_read + item_len;
 
             let Ok(kvpair) = extract(data.key_val()) else {
                 warn!("Failed to extract data on extract_all!");
@@ -748,10 +840,13 @@ impl StorageListInner {
             iter: self.list.iter_raw(),
         };
         let mut check_crc = Crc32::new();
-        storage
+        let mut bytes_written = 0usize;
+
+        let used = storage
             .push(&Elem::Start { seq_no })
             .await
             .map_err(LoadStoreError::FlashWrite)?;
+        bytes_written += used;
         let mut ctr = 0;
 
         for hdrptr in iter {
@@ -793,26 +888,29 @@ impl StorageListInner {
                 SerData::new(used).ok_or(LoadStoreError::AppError(Error::Serialization))?;
             check_crc.update(serdat.key_val());
             // Try writing to flash
-            storage
+            let used = storage
                 .push(&Elem::Data { data: serdat })
                 .await
                 .map_err(LoadStoreError::FlashWrite)?;
+            bytes_written += used;
             ctr += 1;
         }
         let crc = check_crc.finalize();
 
-        storage
+        let used = storage
             .push(&Elem::End {
                 seq_no,
                 calc_crc: crc,
             })
             .await
             .map_err(LoadStoreError::FlashWrite)?;
+        bytes_written += used;
 
         Ok(WriteReport {
             seq: seq_no,
             crc,
             ct: ctr,
+            bytes_written,
         })
     }
 
@@ -1066,43 +1164,51 @@ unsafe fn serialize_node(headerptr: NonNull<NodeHeader>, buf: &mut [u8]) -> Resu
 ///
 async fn verify_list_in_flash<S: NdlDataStorage>(
     storage: &mut S,
-    rpt: WriteReport,
+    rpt: &WriteReport,
     buf: &mut [u8],
+    total_bytes_read: &mut usize,
 ) -> Result<RangeInclusive<usize>, LoadStoreError<S::Error>> {
     // Create a `QueueIterator`
+    let mut total_items_seen_ctr = 0;
     let mut queue_iter = storage
         .iter_elems()
         .await
         .map_err(LoadStoreError::FlashRead)?;
 
     let seq = rpt.seq;
-    let skipres = skip_to_seq!(queue_iter, buf, seq);
-    let start_pos: usize = match skipres {
-        Ok(((), consumed)) => {
-            // The start item was consumed, so subtract one to get the position
-            // of the start item
-            consumed - 1
+
+    // Fast forward until we reach the expected start
+    loop {
+        match queue_iter.next(buf).await {
+            Ok(Some(item)) => {
+                total_items_seen_ctr += 1;
+                *total_bytes_read = *total_bytes_read + item.len();
+                if matches!(item.data(), Some(Elem::Start { seq_no }) if seq_no == seq) {
+                    // Found it!
+                    break;
+                }
+            }
+            Ok(None) => return Err(LoadStoreError::AppError(Error::InconsistentFlash)),
+            Err(e) => return Err(LoadStoreError::FlashRead(e)),
         }
-        // This state should be impossible: we already determined which seq_no to skip to
-        Err(StepErr::EndOfList) => unreachable!("external flash inconsistent"),
-        Err(StepErr::FlashError(e)) => return Err(LoadStoreError::FlashRead(e)),
-    };
+    }
+    // We just saw the start counter, it's position is 1 back from the # of items seen
+    let start_pos = total_items_seen_ctr - 1;
 
     let mut crc = Crc32::new();
     let mut data_items_consumed_ctr = 0;
-    let mut total_items_seen_ctr = start_pos;
     loop {
-        let res = step!(queue_iter, buf);
-        let item = match res {
-            Ok(i) => {
+        let item = match queue_iter.next(buf).await {
+            Ok(Some(i)) => {
                 debug!("visiting {:?} in verify", i.data());
+                *total_bytes_read = *total_bytes_read + i.len();
                 i
             }
-            Err(StepErr::EndOfList) => {
+            Ok(None) => {
                 debug!("Surprising end of list");
                 return Err(LoadStoreError::WriteVerificationFailed);
             }
-            Err(StepErr::FlashError(e)) => return Err(LoadStoreError::FlashRead(e)),
+            Err(e) => return Err(LoadStoreError::FlashRead(e)),
         };
         total_items_seen_ctr += 1;
 

--- a/crates/cfg-noodle/tests/gc_handles_bad_contents.rs
+++ b/crates/cfg-noodle/tests/gc_handles_bad_contents.rs
@@ -47,7 +47,7 @@ async fn gc_handles_bad_contents_inner() {
         let TestElem::End {
             seq_no: _,
             calc_crc,
-        } = item.elem.as_mut().unwrap()
+        } = &mut item.elem
         else {
             panic!()
         };
@@ -72,7 +72,7 @@ async fn gc_handles_bad_contents_inner() {
         let TestElem::End {
             seq_no: _,
             calc_crc,
-        } = item.elem.as_mut().unwrap()
+        } = &mut item.elem
         else {
             panic!()
         };
@@ -127,16 +127,16 @@ async fn gc_handles_bad_contents_inner() {
     // everything that is not reasonable data.
     #[rustfmt::skip]
     let expected: &[_] = &[
-        TestItem { ctr: 10, elem: Some(TestElem::Start { seq_no: NonZeroU32::new(5).unwrap() }) },
-            TestItem { ctr: 11, elem: Some(TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 49, 129, 13] }) },
-            TestItem { ctr: 12, elem: Some(TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 50, 129, 14] }) },
-            TestItem { ctr: 13, elem: Some(TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 51, 129, 15] }) },
-        TestItem { ctr: 14, elem: Some(TestElem::End { seq_no: NonZeroU32::new(5).unwrap(), calc_crc: 2695063543 }) },
-        TestItem { ctr: 25, elem: Some(TestElem::Start { seq_no: NonZeroU32::new(6).unwrap() }) },
-            TestItem { ctr: 26, elem: Some(TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 49, 129, 24, 33] }) },
-            TestItem { ctr: 27, elem: Some(TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 50, 129, 24, 34] }) },
-            TestItem { ctr: 28, elem: Some(TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 51, 129, 24, 35] }) },
-        TestItem { ctr: 29, elem: Some(TestElem::End { seq_no: NonZeroU32::new(6).unwrap(), calc_crc: 2808308182 }) },
+        TestItem { ctr: 10, elem: TestElem::Start { seq_no: NonZeroU32::new(5).unwrap() } },
+            TestItem { ctr: 11, elem: TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 49, 129, 13] } },
+            TestItem { ctr: 12, elem: TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 50, 129, 14] } },
+            TestItem { ctr: 13, elem: TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 51, 129, 15] } },
+        TestItem { ctr: 14, elem: TestElem::End { seq_no: NonZeroU32::new(5).unwrap(), calc_crc: 2695063543 } },
+        TestItem { ctr: 25, elem: TestElem::Start { seq_no: NonZeroU32::new(6).unwrap() } },
+            TestItem { ctr: 26, elem: TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 49, 129, 24, 33] } },
+            TestItem { ctr: 27, elem: TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 50, 129, 24, 34] } },
+            TestItem { ctr: 28, elem: TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 51, 129, 24, 35] } },
+        TestItem { ctr: 29, elem: TestElem::End { seq_no: NonZeroU32::new(6).unwrap(), calc_crc: 2808308182 } },
     ];
     let items = &rpt.flash.items;
     assert_eq!(expected, items);

--- a/crates/cfg-noodle/tests/integration_tests.rs
+++ b/crates/cfg-noodle/tests/integration_tests.rs
@@ -295,12 +295,12 @@ async fn test_read_interrupted_write() {
             let mut iter = flash.items.iter_mut();
             loop {
                 let item = iter.next().unwrap();
-                if matches!(item.elem, Some(TestElem::Start { seq_no }) if seq_no == NonZeroU32::new(2).unwrap()) {
+                if matches!(item.elem, TestElem::Start { seq_no } if seq_no == NonZeroU32::new(2).unwrap()) {
                     break;
                 }
             }
             let item = iter.next().unwrap();
-            let Some(TestElem::Data { data }) = &mut item.elem else {
+            let TestElem::Data { data } = &mut item.elem else {
                 panic!();
             };
             *data.get_mut(3).unwrap() = 0xFF;

--- a/crates/cfg-noodle/tests/many_good_writes.rs
+++ b/crates/cfg-noodle/tests/many_good_writes.rs
@@ -66,23 +66,23 @@ async fn many_good_writes_inner() {
     #[rustfmt::skip]
     let expected = &[
         // Oldest item, seq_no 997
-        TestItem { ctr: 4980, elem: Some(TestElem::Start { seq_no: NonZeroU32::new(997).unwrap() }) },
-            TestItem { ctr: 4981, elem: Some(TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 51, 129, 26, 0, 1, 133, 116] }) },
-            TestItem { ctr: 4982, elem: Some(TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 50, 129, 25, 38, 242] }) },
-            TestItem { ctr: 4983, elem: Some(TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 49, 129, 25, 3, 229] }) },
-        TestItem { ctr: 4984, elem: Some(TestElem::End { seq_no: NonZeroU32::new(997).unwrap(), calc_crc: 2789166760 }) },
+        TestItem { ctr: 4980, elem: TestElem::Start { seq_no: NonZeroU32::new(997).unwrap() } },
+            TestItem { ctr: 4981, elem: TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 51, 129, 26, 0, 1, 133, 116] } },
+            TestItem { ctr: 4982, elem: TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 50, 129, 25, 38, 242] } },
+            TestItem { ctr: 4983, elem: TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 49, 129, 25, 3, 229] } },
+        TestItem { ctr: 4984, elem: TestElem::End { seq_no: NonZeroU32::new(997).unwrap(), calc_crc: 2789166760 } },
         // Middle item, seq_no 998
-        TestItem { ctr: 4985, elem: Some(TestElem::Start { seq_no: NonZeroU32::new(998).unwrap() }) },
-            TestItem { ctr: 4986, elem: Some(TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 51, 129, 26, 0, 1, 133, 216] }) },
-            TestItem { ctr: 4987, elem: Some(TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 50, 129, 25, 38, 252] }) },
-            TestItem { ctr: 4988, elem: Some(TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 49, 129, 25, 3, 230] }) },
-        TestItem { ctr: 4989, elem: Some(TestElem::End { seq_no: NonZeroU32::new(998).unwrap(), calc_crc: 1413754379 }) },
+        TestItem { ctr: 4985, elem: TestElem::Start { seq_no: NonZeroU32::new(998).unwrap() } },
+            TestItem { ctr: 4986, elem: TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 51, 129, 26, 0, 1, 133, 216] } },
+            TestItem { ctr: 4987, elem: TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 50, 129, 25, 38, 252] } },
+            TestItem { ctr: 4988, elem: TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 49, 129, 25, 3, 230] } },
+        TestItem { ctr: 4989, elem: TestElem::End { seq_no: NonZeroU32::new(998).unwrap(), calc_crc: 1413754379 } },
         // Newest item, seq_no 999
-        TestItem { ctr: 4990, elem: Some(TestElem::Start { seq_no: NonZeroU32::new(999).unwrap() }) },
-            TestItem { ctr: 4991, elem: Some(TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 51, 129, 26, 0, 1, 134, 60] }) },
-            TestItem { ctr: 4992, elem: Some(TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 50, 129, 25, 39, 6] }) },
-            TestItem { ctr: 4993, elem: Some(TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 49, 129, 25, 3, 231] }) },
-        TestItem { ctr: 4994, elem: Some(TestElem::End { seq_no: NonZeroU32::new(999).unwrap(), calc_crc: 2388236464 }) },
+        TestItem { ctr: 4990, elem: TestElem::Start { seq_no: NonZeroU32::new(999).unwrap() } },
+            TestItem { ctr: 4991, elem: TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 51, 129, 26, 0, 1, 134, 60] } },
+            TestItem { ctr: 4992, elem: TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 50, 129, 25, 39, 6] } },
+            TestItem { ctr: 4993, elem: TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 49, 129, 25, 3, 231] } },
+        TestItem { ctr: 4994, elem: TestElem::End { seq_no: NonZeroU32::new(999).unwrap(), calc_crc: 2388236464 } },
     ];
 
     assert_eq!(contents, expected);
@@ -157,23 +157,23 @@ async fn many_good_writes_inner() {
     #[rustfmt::skip]
     let expected2 = &[
         // Oldest item, seq_no 998
-        TestItem { ctr: 4985, elem: Some(TestElem::Start { seq_no: NonZeroU32::new(998).unwrap() }) },
-            TestItem { ctr: 4986, elem: Some(TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 51, 129, 26, 0, 1, 133, 216] }) },
-            TestItem { ctr: 4987, elem: Some(TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 50, 129, 25, 38, 252] }) },
-            TestItem { ctr: 4988, elem: Some(TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 49, 129, 25, 3, 230] }) },
-        TestItem { ctr: 4989, elem: Some(TestElem::End { seq_no: NonZeroU32::new(998).unwrap(), calc_crc: 1413754379 }) },
+        TestItem { ctr: 4985, elem: TestElem::Start { seq_no: NonZeroU32::new(998).unwrap() } },
+            TestItem { ctr: 4986, elem: TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 51, 129, 26, 0, 1, 133, 216] } },
+            TestItem { ctr: 4987, elem: TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 50, 129, 25, 38, 252] } },
+            TestItem { ctr: 4988, elem: TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 49, 129, 25, 3, 230] } },
+        TestItem { ctr: 4989, elem: TestElem::End { seq_no: NonZeroU32::new(998).unwrap(), calc_crc: 1413754379 } },
         // Middle item, seq_no 999
-        TestItem { ctr: 4990, elem: Some(TestElem::Start { seq_no: NonZeroU32::new(999).unwrap() }) },
-            TestItem { ctr: 4991, elem: Some(TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 51, 129, 26, 0, 1, 134, 60] }) },
-            TestItem { ctr: 4992, elem: Some(TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 50, 129, 25, 39, 6] }) },
-            TestItem { ctr: 4993, elem: Some(TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 49, 129, 25, 3, 231] }) },
-        TestItem { ctr: 4994, elem: Some(TestElem::End { seq_no: NonZeroU32::new(999).unwrap(), calc_crc: 2388236464 }) },
+        TestItem { ctr: 4990, elem: TestElem::Start { seq_no: NonZeroU32::new(999).unwrap() } },
+            TestItem { ctr: 4991, elem: TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 51, 129, 26, 0, 1, 134, 60] } },
+            TestItem { ctr: 4992, elem: TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 50, 129, 25, 39, 6] } },
+            TestItem { ctr: 4993, elem: TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 49, 129, 25, 3, 231] } },
+        TestItem { ctr: 4994, elem: TestElem::End { seq_no: NonZeroU32::new(999).unwrap(), calc_crc: 2388236464 } },
         // Newest item, seq_no 1000
-        TestItem { ctr: 4995, elem: Some(TestElem::Start { seq_no: NonZeroU32::new(1000).unwrap() }) },
-            TestItem { ctr: 4996, elem: Some(TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 51, 129, 26, 0, 1, 134, 160] }) },
-            TestItem { ctr: 4997, elem: Some(TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 50, 129, 25, 39, 16] }) },
-            TestItem { ctr: 4998, elem: Some(TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 49, 129, 25, 3, 232] }) },
-        TestItem { ctr: 4999, elem: Some(TestElem::End { seq_no: NonZeroU32::new(1000).unwrap(), calc_crc: 2217662377 }) },
+        TestItem { ctr: 4995, elem: TestElem::Start { seq_no: NonZeroU32::new(1000).unwrap() } },
+            TestItem { ctr: 4996, elem: TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 51, 129, 26, 0, 1, 134, 160] } },
+            TestItem { ctr: 4997, elem: TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 50, 129, 25, 39, 16] } },
+            TestItem { ctr: 4998, elem: TestElem::Data { data: vec![1, 108, 116, 101, 115, 116, 47, 99, 111, 110, 102, 105, 103, 49, 129, 25, 3, 232] } },
+        TestItem { ctr: 4999, elem: TestElem::End { seq_no: NonZeroU32::new(1000).unwrap(), calc_crc: 2217662377 } },
     ];
 
     let contents = &rpt.flash.items;

--- a/demos/nrf52840/src/noodle.rs
+++ b/demos/nrf52840/src/noodle.rs
@@ -311,8 +311,9 @@ pub async fn worker(flash: DkMX25R) {
                 // Perform the read
                 info!("worker task got needs_read signal");
                 let start = Instant::now();
-                if let Err(e) = LIST.process_reads(&mut flash, buf).await {
-                    error!("Error in process_reads: {:?}", e);
+                match LIST.process_reads(&mut flash, buf).await {
+                    Ok(rpt) => info!("process_reads success: {:?}", rpt),
+                    Err(e) => error!("Error in process_reads: {:?}", e),
                 }
                 info!("read completed in {:?}", start.elapsed());
 
@@ -331,10 +332,12 @@ pub async fn worker(flash: DkMX25R) {
                 // `StorageList::process_garbage`'s documentation for more details.
                 if !first_gc_done {
                     let start = Instant::now();
-                    if let Err(e) = LIST.process_garbage(&mut flash, buf).await {
-                        error!("Error in process_garbage: {:?}", e);
-                    } else {
-                        first_gc_done = true;
+                    match LIST.process_garbage(&mut flash, buf).await {
+                        Ok(rpt) => {
+                            info!("process_garbage success: {:?}", rpt);
+                            first_gc_done = true;
+                        }
+                        Err(e) => error!("Error in process_garbage: {:?}", e),
                     }
                     info!("(first) gc completed in {:?}", start.elapsed());
                 }
@@ -343,8 +346,9 @@ pub async fn worker(flash: DkMX25R) {
                 // Perform the write
                 info!("worker task got needs_write signal");
                 let start = Instant::now();
-                if let Err(e) = LIST.process_writes(&mut flash, buf).await {
-                    error!("Error in process_writes: {:?}", e);
+                match LIST.process_writes(&mut flash, buf).await {
+                    Ok(rpt) => info!("process_writes success: {:?}", rpt),
+                    Err(e) => error!("Error in process_writes: {:?}", e),
                 }
                 info!("write completed in {:?}", start.elapsed());
 
@@ -352,8 +356,9 @@ pub async fn worker(flash: DkMX25R) {
                 // before the next write will succeed. In this example, we just always perform
                 // garbage collection after writing. See above for more on garbage collection.
                 let start = Instant::now();
-                if let Err(e) = LIST.process_garbage(&mut flash, buf).await {
-                    error!("Error in process_garbage: {:?}", e);
+                match LIST.process_garbage(&mut flash, buf).await {
+                    Ok(rpt) => info!("process_garbage success: {:?}", rpt),
+                    Err(e) => error!("Error in process_garbage: {:?}", e),
                 }
                 info!("gc completed in {:?}", start.elapsed());
             }


### PR DESCRIPTION
Closes #81

I also got rid of the macros, they did not bring joy, and I was no longer using them.

I also noticed that the test storage has an `Option` around the test elem, but it was no longer used, so I removed that as well.