### PR TITLE
Add definition of bit masking for versioning

### DIFF
--- a/crates/cfg-noodle/src/flash.rs
+++ b/crates/cfg-noodle/src/flash.rs
@@ -53,6 +53,15 @@ enum HalfElem {
     End { seq_no: NonZeroU32, calc_crc: u32 },
 }
 
+/// We only support v0 start
+const V0_START: u8 = consts::ELEM_VERSION_V0 | consts::ELEM_DISCRIMINANT_START;
+
+/// We only support v0 data
+const V0_DATA: u8 = consts::ELEM_VERSION_V0 | consts::ELEM_DISCRIMINANT_DATA;
+
+/// We only support v0 end
+const V0_END: u8 = consts::ELEM_VERSION_V0 | consts::ELEM_DISCRIMINANT_END;
+
 // ---- impl Flash ----
 
 impl<T: MultiwriteNorFlash, C: CacheImpl> Flash<T, C> {
@@ -101,13 +110,13 @@ where
         let used = match data {
             Elem::Start { seq_no } => {
                 let buf = &mut buf[..5];
-                buf[0] = consts::ELEM_VERSION_V0 | consts::ELEM_DISCRIMINANT_START;
+                buf[0] = V0_START;
                 buf[1..5].copy_from_slice(&seq_no.get().to_le_bytes());
                 buf
             }
             Elem::Data { data } => data.hdr_key_val,
             Elem::End { seq_no, calc_crc } => {
-                buf[0] = consts::ELEM_VERSION_V0 | consts::ELEM_DISCRIMINANT_END;
+                buf[0] = V0_END;
                 buf[1..5].copy_from_slice(&seq_no.get().to_le_bytes());
                 buf[5..9].copy_from_slice(&calc_crc.to_le_bytes());
                 buf.as_slice()
@@ -211,13 +220,9 @@ impl<T: MultiwriteNorFlash, C: CacheImpl> NdlElemIterNode for FlashNode<'_, '_, 
 
 impl HalfElem {
     fn from_bytes(data: &[u8]) -> Option<Self> {
-        const START: u8 = consts::ELEM_VERSION_V0 | consts::ELEM_DISCRIMINANT_START;
-        const DATA: u8 = consts::ELEM_VERSION_V0 | consts::ELEM_DISCRIMINANT_DATA;
-        const END: u8 = consts::ELEM_VERSION_V0 | consts::ELEM_DISCRIMINANT_END;
-
         let (first, rest) = data.split_first()?;
         match *first {
-            START => {
+            V0_START => {
                 if rest.len() != 4 {
                     return None;
                 }
@@ -227,14 +232,14 @@ impl HalfElem {
                     seq_no: NonZeroU32::new(u32::from_le_bytes(bytes))?,
                 })
             }
-            DATA => {
+            V0_DATA => {
                 if rest.is_empty() {
                     None
                 } else {
                     Some(HalfElem::Data)
                 }
             }
-            END => {
+            V0_END => {
                 if rest.len() != 8 {
                     return None;
                 }

--- a/crates/cfg-noodle/src/lib.rs
+++ b/crates/cfg-noodle/src/lib.rs
@@ -1,6 +1,5 @@
 //! Configuration management
 #![doc = include_str!("../../../README.md")]
-
 #![cfg_attr(not(any(test, doctest, feature = "std")), no_std)]
 #![warn(missing_docs)]
 #![deny(clippy::unwrap_used)]
@@ -154,7 +153,7 @@ impl<'a> SerData<'a> {
     /// Returns None if the slice is empty.
     pub fn new(data: &'a mut [u8]) -> Option<Self> {
         let f = data.first_mut()?;
-        *f = consts::ELEM_DISCRIMINANT_DATA;
+        *f = consts::ELEM_VERSION_V0 | consts::ELEM_DISCRIMINANT_DATA;
 
         Some(Self { hdr_key_val: data })
     }

--- a/crates/cfg-noodle/src/lib.rs
+++ b/crates/cfg-noodle/src/lib.rs
@@ -114,13 +114,26 @@ const fn max(a: usize, b: usize) -> usize {
     if a > b { a } else { b }
 }
 
-mod consts {
+/// Constant values
+///
+/// Currently, this is largely to encode the header byte of [`Elem`]s, which
+/// use the upper 4 bits for "version" (currently only [`ELEM_VERSION_V0`] is supported),
+/// and the lower 4 bits for "discriminant".
+pub mod consts {
+    /// Mask for the "Version" portion of the element byte
+    pub const ELEM_VERSION_MASK: u8 = 0b1111_0000;
+    /// Mask for the "Discriminant" portion of the element byte
+    pub const ELEM_DISCRIMINANT_MASK: u8 = 0b0000_1111;
+
+    /// Current Elem version
+    pub const ELEM_VERSION_V0: u8 = 0b0000_0000;
+
     /// Discriminant used to mark Start elements on disk
-    pub(crate) const ELEM_START: u8 = 0;
+    pub const ELEM_DISCRIMINANT_START: u8 = 0b0000_0000;
     /// Discriminant used to mark Data elements on disk
-    pub(crate) const ELEM_DATA: u8 = 1;
+    pub const ELEM_DISCRIMINANT_DATA: u8 = 0b0000_0001;
     /// Discriminant used to mark End elements on disk
-    pub(crate) const ELEM_END: u8 = 2;
+    pub const ELEM_DISCRIMINANT_END: u8 = 0b0000_0010;
 }
 
 /// Serialized Data Element
@@ -141,7 +154,7 @@ impl<'a> SerData<'a> {
     /// Returns None if the slice is empty.
     pub fn new(data: &'a mut [u8]) -> Option<Self> {
         let f = data.first_mut()?;
-        *f = consts::ELEM_DATA;
+        *f = consts::ELEM_DISCRIMINANT_DATA;
 
         Some(Self { hdr_key_val: data })
     }


### PR DESCRIPTION
This doesn't actually change anything in the binary format, only formally defines the split, with us currently using v0 (upper bits all zero).