### PR TITLE
Make it compile on windows

### DIFF
--- a/crates/cfg-noodle/.vscode/settings.json
+++ b/crates/cfg-noodle/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "rust-analyzer.cargo.features": ["std"]
+}

--- a/crates/cfg-noodle/Cargo.lock
+++ b/crates/cfg-noodle/Cargo.lock
@@ -148,6 +148,7 @@ dependencies = [
  "crc",
  "critical-section",
  "defmt 1.0.1",
+ "embassy-executor",
  "embassy-futures",
  "embassy-sync",
  "embassy-time",

--- a/crates/cfg-noodle/Cargo.toml
+++ b/crates/cfg-noodle/Cargo.toml
@@ -40,6 +40,7 @@ std = [
     "dep:log",
     "dep:simple_logger",
     "dep:tokio",
+    "dep:embassy-executor",
 ]
 defmt = [
     "dep:defmt",
@@ -69,14 +70,15 @@ mutex-traits            = "1.0.0"
 pin-project             = "1.1.10"
 sequential-storage      = "4.0.3"
 
-cordyceps       = { version = "0.3.4", default-features = false }
-defmt           = { version = "1.0.1", optional = true }
-log             = { version = "0.4.27", optional = true }
-maitake-sync    = { version = "0.2.1", default-features = false }
-minicbor        = { version = "1.0.0", default-features = false, features = ["derive"] }
-mutex           = { version = "1.0.0", features = ["impl-critical-section"] }
-simple_logger   = { version = "5.0.0", optional = true }
-tokio           = { version = "1.45.1", optional = true, features = ["macros", "rt-multi-thread", "time"] }
+cordyceps        = { version = "0.3.4", default-features = false }
+defmt            = { version = "1.0.1", optional = true }
+log              = { version = "0.4.27", optional = true }
+maitake-sync     = { version = "0.2.1", default-features = false }
+minicbor         = { version = "1.0.0", default-features = false, features = ["derive"] }
+mutex            = { version = "1.0.0", features = ["impl-critical-section"] }
+simple_logger    = { version = "5.0.0", optional = true }
+tokio            = { version = "1.45.1", optional = true, features = ["macros", "rt-multi-thread", "time"] }
+embassy-executor = { version = "0.7.0", optional = true, features = ["arch-std", "executor-thread"] } # Required to get this crate compiled on windows under std
 
 [dev-dependencies]
 approx          = "0.5.1"


### PR DESCRIPTION
Windows is little sensitive when it comes to linking.
I opened an issue in embassy, but the design and choices there make this a low prio issue.
https://github.com/embassy-rs/embassy/pull/4433

So, instead let's solve it here.

Also added the std feature for rust-analyzer so my editor is happy