### PR TITLE
Expose the extracted kv-pair to the outside world so people can look at the cbor bytes

### DIFF
--- a/crates/cfg-noodle/src/flash.rs
+++ b/crates/cfg-noodle/src/flash.rs
@@ -153,9 +153,7 @@ where
 
 // ---- impl FlashIter ----
 
-impl<'flash, T: MultiwriteNorFlash, C: CacheImpl> NdlElemIter
-    for FlashIter<'flash, T, C>
-{
+impl<'flash, T: MultiwriteNorFlash, C: CacheImpl> NdlElemIter for FlashIter<'flash, T, C> {
     type Item<'this, 'buf>
         = FlashNode<'flash, 'this, 'buf, T, C>
     where


### PR DESCRIPTION
(Pr is on top of #96)

We've got a situation where we need to inspect the cbor bytes outside of the normal storage list (reading it from a dump).
This PR exposes the least amount of information required to do that.