### PR TITLE
Update cfg-noodle to sequential-storage 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Unreleased
 
+- *Breaking:* Updated to sequential-storage 8
+
 ## 0.7.0 16-04-26
 
 - *Breaking:* Updated embassy dependencies

--- a/crates/cfg-noodle/Cargo.toml
+++ b/crates/cfg-noodle/Cargo.toml
@@ -76,7 +76,7 @@ embassy-time            = { version = "0.5.0", optional = true }
 embedded-storage-async  = "0.4.1"
 mutex-traits            = "1.0.0"
 pin-project             = "1.1.10"
-sequential-storage      = "7.0.0"
+sequential-storage      = "8.0.0"
 
 cordyceps        = { version = "0.3.4", default-features = false }
 defmt            = { version = "1.0.1", optional = true }

--- a/crates/cfg-noodle/src/flash.rs
+++ b/crates/cfg-noodle/src/flash.rs
@@ -6,7 +6,7 @@ use core::{num::NonZeroU32, ops::Deref};
 
 use embedded_storage_async::nor_flash::{ErrorType, MultiwriteNorFlash};
 use sequential_storage::{
-    cache::{CacheImpl, NoCache},
+    cache::{Cache, CacheImpl, Uncached},
     queue::{QueueConfig, QueueIterator, QueueIteratorEntry, QueueStorage},
 };
 
@@ -15,12 +15,12 @@ use crate::{
 };
 
 /// Owns a flash and the range reserved for the `StorageList`
-pub struct Flash<T: MultiwriteNorFlash, C: CacheImpl> {
+pub struct Flash<T: MultiwriteNorFlash, C: CacheImpl<()>> {
     queue: QueueStorage<T, C>,
 }
 
 /// An iterator over a [`Flash`]
-pub struct FlashIter<'flash, T: MultiwriteNorFlash, C: CacheImpl> {
+pub struct FlashIter<'flash, T: MultiwriteNorFlash, C: CacheImpl<()>> {
     iter: QueueIterator<'flash, T, C>,
 }
 
@@ -28,7 +28,7 @@ pub struct FlashIter<'flash, T: MultiwriteNorFlash, C: CacheImpl> {
 ///
 /// This represents a well-decoded element, where `half` contains the decoded
 /// contents that correspond with `qit`.
-pub struct FlashNode<'flash, 'iter, 'buf, T: MultiwriteNorFlash, C: CacheImpl> {
+pub struct FlashNode<'flash, 'iter, 'buf, T: MultiwriteNorFlash, C: CacheImpl<()>> {
     half: Option<HalfElem>,
     qit: QueueIteratorEntry<'flash, 'buf, 'iter, T, C>,
 }
@@ -62,7 +62,7 @@ const V0_END: u8 = consts::ELEM_VERSION_V0 | consts::ELEM_DISCRIMINANT_END;
 
 // ---- impl Flash ----
 
-impl<T: MultiwriteNorFlash, C: CacheImpl> Flash<T, C> {
+impl<T: MultiwriteNorFlash, C: CacheImpl<()>> Flash<T, C> {
     /// Creates a new Flash instance with the given flash device and address range.
     ///
     /// # Arguments
@@ -86,7 +86,7 @@ impl<T: MultiwriteNorFlash, C: CacheImpl> Flash<T, C> {
     /// * `range` - The address range within the flash device reserved for this storage
     /// * `cache` - the cache to use with this flash access
     pub fn try_new(flash: T, range: core::ops::Range<u32>, cache: C) -> Option<Self> {
-        let config = QueueConfig::try_new(range)?;
+        let config = QueueConfig::try_new(range).ok()?;
         Some(Self {
             queue: QueueStorage::new(flash, config, cache),
         })
@@ -103,7 +103,7 @@ impl<T: MultiwriteNorFlash, C: CacheImpl> Flash<T, C> {
     }
 }
 
-impl<T: MultiwriteNorFlash, C: CacheImpl> NdlDataStorage for Flash<T, C>
+impl<T: MultiwriteNorFlash, C: CacheImpl<()>> NdlDataStorage for Flash<T, C>
 where
     <T as ErrorType>::Error: MaybeDefmtFormat,
 {
@@ -164,7 +164,7 @@ where
 
 // ---- impl FlashIter ----
 
-impl<'flash, T: MultiwriteNorFlash, C: CacheImpl> NdlElemIter for FlashIter<'flash, T, C> {
+impl<'flash, T: MultiwriteNorFlash, C: CacheImpl<()>> NdlElemIter for FlashIter<'flash, T, C> {
     type Item<'this, 'buf>
         = FlashNode<'flash, 'this, 'buf, T, C>
     where
@@ -199,7 +199,7 @@ impl<'flash, T: MultiwriteNorFlash, C: CacheImpl> NdlElemIter for FlashIter<'fla
 
 // ---- impl FlashIterNode ----
 
-impl<T: MultiwriteNorFlash, C: CacheImpl> NdlElemIterNode for FlashNode<'_, '_, '_, T, C> {
+impl<T: MultiwriteNorFlash, C: CacheImpl<()>> NdlElemIterNode for FlashNode<'_, '_, '_, T, C> {
     type Error = sequential_storage::Error<<T as ErrorType>::Error>;
 
     fn data(&self) -> Option<Elem<'_>> {
@@ -275,7 +275,8 @@ where
     T: MultiwriteNorFlash,
 {
     // Items pushed to the queue have overhead
-    let baseline_overhead = QueueStorage::<T, NoCache>::item_overhead_size() as usize;
+    let baseline_overhead =
+        QueueStorage::<T, Cache<Uncached, Uncached, Uncached>>::item_overhead_size() as usize;
     // Items pushed to the queue require some alignment padding
     let len_roundup = len.next_multiple_of(crate::max(T::WRITE_SIZE, T::READ_SIZE));
 

--- a/crates/cfg-noodle/src/flash.rs
+++ b/crates/cfg-noodle/src/flash.rs
@@ -7,7 +7,7 @@ use core::{num::NonZeroU32, ops::Deref};
 use embedded_storage_async::nor_flash::{ErrorType, MultiwriteNorFlash};
 use sequential_storage::{
     cache::{Cache, CacheImpl, Uncached},
-    queue::{QueueConfig, QueueIterator, QueueIteratorEntry, QueueStorage},
+    queue::{QueueConfig, QueueConfigError, QueueIterator, QueueIteratorEntry, QueueStorage},
 };
 
 use crate::{
@@ -85,9 +85,13 @@ impl<T: MultiwriteNorFlash, C: CacheImpl<()>> Flash<T, C> {
     /// * `flash` - The MultiwriteNorFlash device to use for storage operations
     /// * `range` - The address range within the flash device reserved for this storage
     /// * `cache` - the cache to use with this flash access
-    pub fn try_new(flash: T, range: core::ops::Range<u32>, cache: C) -> Option<Self> {
-        let config = QueueConfig::try_new(range).ok()?;
-        Some(Self {
+    pub fn try_new(
+        flash: T,
+        range: core::ops::Range<u32>,
+        cache: C,
+    ) -> Result<Self, QueueConfigError> {
+        let config = QueueConfig::try_new(range)?;
+        Ok(Self {
             queue: QueueStorage::new(flash, config, cache),
         })
     }

--- a/crates/cfg-noodle/src/test_utils.rs
+++ b/crates/cfg-noodle/src/test_utils.rs
@@ -11,7 +11,7 @@ use maitake_sync::WaitQueue;
 use minicbor::encode::write::{Cursor, EndOfSlice};
 use mutex_traits::ScopedRawMutex;
 use sequential_storage::{
-    cache::NoCache,
+    cache::{Cache, Uncached},
     mock_flash::{MockFlashBase, WriteCountCheck},
 };
 use tokio::select;
@@ -99,7 +99,7 @@ pub struct WorkerReport {
 // TODO: This type, the get_mock_flash() and worker_task() are not only specific to sequential storage's
 // mock flash, but also copy&pasted in the integration tests. If we go with the flash-trait approach,
 // these could be generic.
-pub type MockFlash = Flash<MockFlashBase<10, 16, 256>, NoCache>;
+pub type MockFlash = Flash<MockFlashBase<10, 16, 256>, Cache<Uncached, Uncached, Uncached>>;
 
 // ---- impl TestStorage ----
 
@@ -400,7 +400,7 @@ pub fn get_mock_flash() -> MockFlash {
     // TODO: Figure out why miri tests with unaligned buffers and whether
     // this needs any fixing. For now just disable the alignment check in MockFlash
     flash.alignment_check = !cfg!(miri);
-    Flash::new(flash, 0x0000..0x1000, NoCache::new())
+    Flash::new(flash, 0x0000..0x1000, Cache::new_uncached())
 }
 
 /// A simple worker task for sequential-storage based testing

--- a/demos/nrf52840-load/Cargo.lock
+++ b/demos/nrf52840-load/Cargo.lock
@@ -971,9 +971,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "sequential-storage"
-version = "7.0.0"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634c2d26969edcb6b2c24c35cce4849c42199cd3ad32c69f6e5e02365ab60e76"
+checksum = "e750f14f4f6e5a81277c66311713a56106c8df0196df62a634d1fc806556832b"
 dependencies = [
  "defmt",
  "embedded-storage-async",

--- a/demos/nrf52840-load/Cargo.toml
+++ b/demos/nrf52840-load/Cargo.toml
@@ -24,7 +24,7 @@ defmt                   = "1.0.1"
 defmt-rtt               = "1.0.0"
 embassy-embedded-hal    = "0.5.0"
 embassy-futures         = "0.1.2"
-sequential-storage      = "7.0.0"
+sequential-storage      = "8.0.0"
 static_cell             = "2.1"
 maitake-sync = { version = "0.2.2", default-features = false, features = ["critical-section"] }
 

--- a/demos/nrf52840-load/src/noodle/mod.rs
+++ b/demos/nrf52840-load/src/noodle/mod.rs
@@ -6,7 +6,9 @@ use embassy_futures::select::{select, Either};
 use embassy_time::{Duration, Instant, Timer, WithTimeout};
 use mutex::raw_impls::cs::CriticalSectionRawMutex;
 use mx25r::SECTOR_SIZE;
-use sequential_storage::cache::PagePointerCache;
+use sequential_storage::cache::{
+    page_pointers::ArrayPagePointers, page_states::ArrayPageStates, Cache, Uncached,
+};
 use static_cell::ConstStaticCell;
 
 use crate::DkMX25R;
@@ -32,6 +34,8 @@ const TOTAL_SIZE: usize = 128 * 1024;
 // "the granularity that we can erase", which is sectors on our flash part.
 const PAGE_COUNT: usize = const { TOTAL_SIZE / (SECTOR_SIZE as usize) };
 
+type PageCache = Cache<ArrayPageStates<PAGE_COUNT>, ArrayPagePointers<PAGE_COUNT>, Uncached>;
+
 // Create a static list that will contain all of our nodes.
 //
 // This is generic over the kind of mutex. If you do not access the list in interrupt
@@ -42,7 +46,7 @@ pub static LIST: StorageList<CriticalSectionRawMutex, 3> = StorageList::new();
 // We put our scratch buffer in a `ConstStaticCell` to avoid ever creating it on the stack.
 //
 // It acts as a static singleton that we can then hold by reference in our I/O worker task.
-const BUF_SZ: usize = Flash::<DkMX25R, PagePointerCache<PAGE_COUNT>>::MAX_ELEM_SIZE;
+const BUF_SZ: usize = Flash::<DkMX25R, PageCache>::MAX_ELEM_SIZE;
 static BUF: ConstStaticCell<[u8; BUF_SZ]> = ConstStaticCell::new([0u8; BUF_SZ]);
 
 // This is the I/O worker task. Most users can use the default worker
@@ -76,7 +80,11 @@ pub async fn worker(
     let mut flash = Flash::new(
         flash,
         0..(TOTAL_SIZE as u32),
-        PagePointerCache::<PAGE_COUNT>::new(),
+        Cache::new(
+            ArrayPageStates::<PAGE_COUNT>::new(),
+            ArrayPagePointers::<PAGE_COUNT>::new(),
+            Uncached,
+        ),
     );
 
     let mut first_gc_done = false;

--- a/demos/nrf52840/Cargo.lock
+++ b/demos/nrf52840/Cargo.lock
@@ -959,9 +959,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "sequential-storage"
-version = "7.0.0"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634c2d26969edcb6b2c24c35cce4849c42199cd3ad32c69f6e5e02365ab60e76"
+checksum = "e750f14f4f6e5a81277c66311713a56106c8df0196df62a634d1fc806556832b"
 dependencies = [
  "defmt 1.0.1",
  "embedded-storage-async",

--- a/demos/nrf52840/src/noodle.rs
+++ b/demos/nrf52840/src/noodle.rs
@@ -8,7 +8,9 @@ use cfg_noodle::{
     flash::Flash,
     minicbor::{self, CborLen, Decode, Encode},
     mutex::raw_impls::cs::CriticalSectionRawMutex,
-    sequential_storage::cache::PagePointerCache,
+    sequential_storage::cache::{
+        page_pointers::ArrayPagePointers, page_states::ArrayPageStates, Cache, Uncached,
+    },
     StorageList, StorageListNode,
 };
 use defmt::{error, info};
@@ -238,7 +240,11 @@ pub async fn worker(flash: DkMX25R) {
     let mut flash = Flash::new(
         flash,
         0..(TOTAL_SIZE as u32),
-        PagePointerCache::<PAGE_COUNT>::new(),
+        Cache::new(
+            ArrayPageStates::<PAGE_COUNT>::new(),
+            ArrayPagePointers::<PAGE_COUNT>::new(),
+            Uncached,
+        ),
     );
 
     let mut first_gc_done = false;


### PR DESCRIPTION
## Summary
- Bump the `sequential-storage` dependency from 7.x to 8.x in cfg-noodle and the nrf52840-load demo.
- Adapt to sequential-storage 8's restructured cache API (`Cache`, `ArrayPageStates`, `ArrayPagePointers`, `Uncached`) and `CacheImpl<()>` bounds for queue usage.
- Handle `QueueConfig::try_new` now returning a `Result` instead of an `Option`.
- Update both nrf52840 demos to use the new page pointer cache setup.

## Notes
This release is disk-compatible with sequential-storage 7, so existing flash data should continue to work without migration.